### PR TITLE
chore: add file organisation rules and enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,9 @@ Thumbs.db
 # Docker
 .docker/
 
+# Workflow run artifacts — generated at runtime, never committed
+outputs/
+
 # Secrets
 *.pem
 *.key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,15 @@
 repos:
+  # Local repo rules — enforce project file organisation
+  - repo: local
+    hooks:
+      - id: no-root-clutter
+        name: Block .md / test_*.py files at repo root
+        entry: python scripts/check_root_clutter.py
+        language: python
+        pass_filenames: true
+        # Run on any staged file (the script filters by location and extension)
+        types_or: [markdown, python]
+
   # Standard file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,18 @@ The YAML parser uses the `id` field (not `role`) for agent-to-role mapping. Temp
 
 `MCPToolBridge` (`tools/mcp_bridge.py`) connects workflow tool references to real MCP servers (PubMed, Ahrefs, Similarweb, etc.) via `MCPToolRegistry` (`tools/registry.py`).
 
+## File Organisation Rules
+
+These are enforced automatically by the pre-commit hook (`scripts/check_root_clutter.py`) — violations are blocked at commit time.
+
+| File type | Correct location | Notes |
+|---|---|---|
+| Documentation (`*.md`) | `docs/` → `docs/guides/`, `docs/phases/`, `docs/reports/` | `README.md` and `CLAUDE.md` are the only `.md` files allowed at root |
+| Test files (`test_*.py`) | `tests/` | Mirrors the module under test; marked `@pytest.mark.integration` if they need a live API key |
+| Bundled workflow YAMLs | `agenticom/bundled_workflows/` | No ad-hoc YAMLs at root |
+| Workflow run artifacts | `outputs/` (gitignored) | Never committed; generated at runtime |
+| One-off scripts / utilities | `scripts/` | Not `orchestration/` and not root |
+
 ## Code Style
 
 - **Formatter**: Black, line length 88

--- a/scripts/check_root_clutter.py
+++ b/scripts/check_root_clutter.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Pre-commit hook: reject misplaced files at the repo root.
+
+Rules enforced:
+  *.md at root      → must go in docs/   (README.md and CLAUDE.md are exempt)
+  test_*.py at root → must go in tests/
+
+Usage (called by pre-commit with staged filenames as argv):
+  python scripts/check_root_clutter.py [file ...]
+"""
+
+import sys
+from pathlib import Path
+
+EXEMPT_MD = {"README.md", "CLAUDE.md"}
+
+violations = []
+
+for arg in sys.argv[1:]:
+    path = Path(arg)
+    # Only flag files directly at the repo root (no parent directory)
+    if path.parent != Path("."):
+        continue
+
+    name = path.name
+
+    if name.endswith(".md") and name not in EXEMPT_MD:
+        violations.append((arg, "docs/"))
+    elif name.startswith("test_") and name.endswith(".py"):
+        violations.append((arg, "tests/"))
+
+if violations:
+    print("❌  Files must not live at the repo root — move them before committing:\n")
+    for filepath, dest in violations:
+        print(f"    {filepath}  →  {dest}")
+    print(
+        "\n    .md files (except README.md / CLAUDE.md) belong in docs/\n"
+        "    test_*.py files belong in tests/"
+    )
+    sys.exit(1)


### PR DESCRIPTION
## Summary

- **`.gitignore`**: add `outputs/` — workflow run artifacts are generated at runtime and should never be committed
- **`scripts/check_root_clutter.py`**: pre-commit hook that blocks `.md` files (except `README.md`/`CLAUDE.md`) and `test_*.py` files from being committed to the repo root
- **`.pre-commit-config.yaml`**: wire in `no-root-clutter` as a local hook (runs before every commit)
- **`CLAUDE.md`**: add File Organisation Rules table so contributors know where each file type belongs

## Why

Root clutter was identified as a recurring problem (45 `.md` files and 6 `test_*.py` files were just cleaned up from root). This PR makes the rules machine-enforced — future violations are blocked at commit time, not discovered during code review.

## Test plan

- [x] Hook passes for exempt files: `README.md`, `CLAUDE.md`, files in subdirs
- [x] Hook blocks `.md` files placed at root
- [x] Hook blocks `test_*.py` files placed at root
- [x] `.gitignore` verified to include `outputs/`